### PR TITLE
[ZEPPELIN-6302] fix: route to home when click note trash button

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
@@ -227,6 +227,7 @@ export class NotebookActionBarComponent extends MessageListenersManager implemen
 
   moveNoteToTrash() {
     this.messageService.moveNoteToTrash(this.note.id);
+    this.router.navigate(['/']);
   }
 
   get isTrash() {


### PR DESCRIPTION
### What is this PR for?
**[Appropriate action - Classic UI]**

https://github.com/user-attachments/assets/b47c3c60-a7f3-45ef-b438-7aadd127134a

In the Classic UI, clicking the trash button takes me to the home screen.



**[AS-IS]**

https://github.com/user-attachments/assets/f4b7d08d-ee33-4c8d-aeda-bb31ebb570db

However, it doesn’t work in the New UI(delete action works well, but it doesn’t navigate to the home screen), so it needs to be fixed.

**[TO-BE]**


https://github.com/user-attachments/assets/c97d9ebd-d75d-47fa-b1ee-55d502058494





I solved it by adding a very simple routing code into the note deletion logic.


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* [[ZEPPELIN-6296](https://issues.apache.org/jira/browse/ZEPPELIN-6302)]

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
