### PR TITLE
[ZEPPELIN-6303] Align JDK requirement to 11 in build guide

### DIFF
--- a/docs/setup/basics/how_to_build.md
+++ b/docs/setup/basics/how_to_build.md
@@ -42,7 +42,7 @@ If you want to build from source, you must first install the following dependenc
   </tr>
   <tr>
     <td>OpenJDK or Oracle JDK</td>
-    <td>1.8 (151+)<br>(set JAVA_HOME)</td>
+    <td>11<br>(set JAVA_HOME)</td>
   </tr>
 </table>
 
@@ -193,7 +193,7 @@ If you don't have requirements prepared, install it.
 ```bash
 sudo apt-get update
 sudo apt-get install git
-sudo apt-get install openjdk-8-jdk
+sudo apt-get install openjdk-11-jdk
 sudo apt-get install npm
 sudo apt-get install libfontconfig
 sudo apt-get install r-base-dev


### PR DESCRIPTION
### What is this PR for?

Currently, the `how_to_build.md` documentation specifies that **Java 1.8** is required to build Zeppelin from source.

However, the project's root `pom.xml` file defines the `java.version` property as **11**.

This discrepancy can confuse new contributors, leading them to set up an incorrect development environment and encounter build failures.

https://github.com/apache/zeppelin/blob/f541b461151d06244f36ac65777fd236170ba001/pom.xml#L100

- In `docs/setup/basics/how_to_build.md`:
  - Change the required JDK version from `1.8` to `11`.
  - Update the sample installation command from `openjdk-8-jdk` to `openjdk-11-jdk`.
  

### What type of PR is it?
Documentation

### Todos
* [x] - Update how_to_build.md docs

### What is the Jira issue?
[[ZEPPELIN-6303]](https://issues.apache.org/jira/browse/ZEPPELIN-6303)

### How should this be tested?
This is a trivial documentation update, so if the current CI passes, there’s no need for additional unit tests.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
