### PR TITLE
[ZEPPELIN-6301] Add tslint custom rule about ensure the order in constructor

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
@@ -286,6 +286,7 @@ export class NotebookActionBarComponent extends MessageListenersManager implemen
 
   constructor(
     public messageService: MessageService,
+    @Inject(TRASH_FOLDER_ID_TOKEN) public TRASH_FOLDER_ID: string,
     private nzModalService: NzModalService,
     private ticketService: TicketService,
     private nzMessageService: NzMessageService,
@@ -293,7 +294,6 @@ export class NotebookActionBarComponent extends MessageListenersManager implemen
     private cdr: ChangeDetectorRef,
     private noteStatusService: NoteStatusService,
     private notebookService: NotebookService,
-    @Inject(TRASH_FOLDER_ID_TOKEN) public TRASH_FOLDER_ID: string,
     private activatedRoute: ActivatedRoute,
     private saveAsService: SaveAsService
   ) {

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -395,15 +395,15 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
   }
 
   constructor(
-    private activatedRoute: ActivatedRoute,
     public messageService: MessageService,
+    protected ngZService: NgZService,
+    private activatedRoute: ActivatedRoute,
     private cdr: ChangeDetectorRef,
     private noteStatusService: NoteStatusService,
     private noteVarShareService: NoteVarShareService,
     private ticketService: TicketService,
     private securityService: SecurityService,
     private router: Router,
-    protected ngZService: NgZService,
     private titleService: Title
   ) {
     super(messageService);

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
@@ -432,15 +432,15 @@ export class NotebookParagraphComponent extends ParagraphBase implements OnInit,
   }
 
   constructor(
-    noteStatusService: NoteStatusService,
-    cdr: ChangeDetectorRef,
-    ngZService: NgZService,
-    private heliumService: HeliumService,
     public messageService: MessageService,
+    private heliumService: HeliumService,
     private nzModalService: NzModalService,
     private noteVarShareService: NoteVarShareService,
     private shortcutService: ShortcutService,
-    private host: ElementRef
+    private host: ElementRef,
+    noteStatusService: NoteStatusService,
+    cdr: ChangeDetectorRef,
+    ngZService: NgZService
   ) {
     super(messageService, noteStatusService, ngZService, cdr);
   }

--- a/zeppelin-web-angular/src/app/pages/workspace/published/paragraph/paragraph.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/published/paragraph/paragraph.component.ts
@@ -37,11 +37,11 @@ export class PublishedParagraphComponent extends ParagraphBase implements Publis
 
   constructor(
     public messageService: MessageService,
+    private activatedRoute: ActivatedRoute,
+    private heliumService: HeliumService,
     noteStatusService: NoteStatusService,
     ngZService: NgZService,
-    cdr: ChangeDetectorRef,
-    private activatedRoute: ActivatedRoute,
-    private heliumService: HeliumService
+    cdr: ChangeDetectorRef
   ) {
     super(messageService, noteStatusService, ngZService, cdr);
     this.activatedRoute.params.subscribe(params => {

--- a/zeppelin-web-angular/src/app/services/configuration.service.ts
+++ b/zeppelin-web-angular/src/app/services/configuration.service.ts
@@ -20,7 +20,7 @@ import { BaseUrlService } from './base-url.service';
   providedIn: 'root'
 })
 export class ConfigurationService extends BaseRest {
-  constructor(baseUrlService: BaseUrlService, private http: HttpClient) {
+  constructor(private http: HttpClient, baseUrlService: BaseUrlService) {
     super(baseUrlService);
   }
 

--- a/zeppelin-web-angular/src/app/services/credential.service.ts
+++ b/zeppelin-web-angular/src/app/services/credential.service.ts
@@ -21,7 +21,7 @@ import { BaseUrlService } from './base-url.service';
   providedIn: 'root'
 })
 export class CredentialService extends BaseRest {
-  constructor(baseUrlService: BaseUrlService, private http: HttpClient) {
+  constructor(private http: HttpClient, baseUrlService: BaseUrlService) {
     super(baseUrlService);
   }
 

--- a/zeppelin-web-angular/src/app/services/interpreter.service.ts
+++ b/zeppelin-web-angular/src/app/services/interpreter.service.ts
@@ -29,7 +29,7 @@ import { BaseUrlService } from './base-url.service';
   providedIn: 'root'
 })
 export class InterpreterService extends BaseRest {
-  constructor(baseUrlService: BaseUrlService, private http: HttpClient) {
+  constructor(private http: HttpClient, baseUrlService: BaseUrlService) {
     super(baseUrlService);
   }
 

--- a/zeppelin-web-angular/src/app/services/job-manager.service.ts
+++ b/zeppelin-web-angular/src/app/services/job-manager.service.ts
@@ -20,7 +20,7 @@ import { BaseUrlService } from './base-url.service';
   providedIn: 'root'
 })
 export class JobManagerService extends BaseRest {
-  constructor(baseUrlService: BaseUrlService, private http: HttpClient) {
+  constructor(private http: HttpClient, baseUrlService: BaseUrlService) {
     super(baseUrlService);
   }
 

--- a/zeppelin-web-angular/src/app/services/notebook-repos.service.ts
+++ b/zeppelin-web-angular/src/app/services/notebook-repos.service.ts
@@ -22,7 +22,7 @@ import { BaseUrlService } from './base-url.service';
   providedIn: 'root'
 })
 export class NotebookRepoService extends BaseRest {
-  constructor(baseUrlService: BaseUrlService, private http: HttpClient) {
+  constructor(private http: HttpClient, baseUrlService: BaseUrlService) {
     super(baseUrlService);
   }
 

--- a/zeppelin-web-angular/src/app/services/notebook.service.ts
+++ b/zeppelin-web-angular/src/app/services/notebook.service.ts
@@ -24,7 +24,7 @@ import { BehaviorSubject } from 'rxjs';
 export class NotebookService extends BaseRest {
   private queryStr$ = new BehaviorSubject<string | null>(null);
 
-  constructor(baseUrlService: BaseUrlService, private http: HttpClient) {
+  constructor(private http: HttpClient, baseUrlService: BaseUrlService) {
     super(baseUrlService);
   }
 

--- a/zeppelin-web-angular/src/app/services/security.service.ts
+++ b/zeppelin-web-angular/src/app/services/security.service.ts
@@ -22,7 +22,7 @@ import { BaseUrlService } from './base-url.service';
   providedIn: 'root'
 })
 export class SecurityService extends BaseRest {
-  constructor(baseUrlService: BaseUrlService, private http: HttpClient) {
+  constructor(private http: HttpClient, baseUrlService: BaseUrlService) {
     super(baseUrlService);
   }
 

--- a/zeppelin-web-angular/src/app/share/header/header.component.ts
+++ b/zeppelin-web-angular/src/app/share/header/header.component.ts
@@ -66,8 +66,8 @@ export class HeaderComponent extends MessageListenersManager implements OnInit, 
 
   constructor(
     public ticketService: TicketService,
-    private nzModalService: NzModalService,
     public messageService: MessageService,
+    private nzModalService: NzModalService,
     private router: Router,
     private notebookService: NotebookService,
     private cdr: ChangeDetectorRef

--- a/zeppelin-web-angular/src/app/share/node-list/node-list.component.ts
+++ b/zeppelin-web-angular/src/app/share/node-list/node-list.component.ts
@@ -135,9 +135,9 @@ export class NodeListComponent extends MessageListenersManager implements OnInit
   }
 
   constructor(
-    private noteListService: NoteListService,
     public messageService: MessageService,
     @Inject(TRASH_FOLDER_ID_TOKEN) public TRASH_FOLDER_ID: string,
+    private noteListService: NoteListService,
     private nzModalService: NzModalService,
     private noteActionService: NoteActionService,
     private cdr: ChangeDetectorRef

--- a/zeppelin-web-angular/src/app/share/note-import/note-import.component.ts
+++ b/zeppelin-web-angular/src/app/share/note-import/note-import.component.ts
@@ -101,8 +101,8 @@ export class NoteImportComponent extends MessageListenersManager implements OnIn
   }
 
   constructor(
-    private ticketService: TicketService,
     public messageService: MessageService,
+    private ticketService: TicketService,
     private cdr: ChangeDetectorRef,
     private nzModalRef: NzModalRef,
     private httpClient: HttpClient

--- a/zeppelin-web-angular/src/app/visualizations/area-chart/area-chart-visualization.ts
+++ b/zeppelin-web-angular/src/app/visualizations/area-chart/area-chart-visualization.ts
@@ -26,7 +26,7 @@ export class AreaChartVisualization extends G2VisualizationBase {
     this.viewContainerRef
   );
 
-  constructor(config: GraphConfig, private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef) {
+  constructor(private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef, config: GraphConfig) {
     super(config);
   }
 }

--- a/zeppelin-web-angular/src/app/visualizations/bar-chart/bar-chart-visualization.ts
+++ b/zeppelin-web-angular/src/app/visualizations/bar-chart/bar-chart-visualization.ts
@@ -25,7 +25,7 @@ export class BarChartVisualization extends G2VisualizationBase {
     this.portalOutlet,
     this.viewContainerRef
   );
-  constructor(config: GraphConfig, private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef) {
+  constructor(private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef, config: GraphConfig) {
     super(config);
   }
 }

--- a/zeppelin-web-angular/src/app/visualizations/line-chart/line-chart-visualization.ts
+++ b/zeppelin-web-angular/src/app/visualizations/line-chart/line-chart-visualization.ts
@@ -26,7 +26,7 @@ export class LineChartVisualization extends G2VisualizationBase {
     this.viewContainerRef
   );
 
-  constructor(config: GraphConfig, private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef) {
+  constructor(private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef, config: GraphConfig) {
     super(config);
   }
 }

--- a/zeppelin-web-angular/src/app/visualizations/pie-chart/pie-chart-visualization.ts
+++ b/zeppelin-web-angular/src/app/visualizations/pie-chart/pie-chart-visualization.ts
@@ -26,7 +26,7 @@ export class PieChartVisualization extends G2VisualizationBase {
     this.viewContainerRef
   );
 
-  constructor(config: GraphConfig, private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef) {
+  constructor(private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef, config: GraphConfig) {
     super(config);
   }
 }

--- a/zeppelin-web-angular/src/app/visualizations/scatter-chart/scatter-chart-visualization.ts
+++ b/zeppelin-web-angular/src/app/visualizations/scatter-chart/scatter-chart-visualization.ts
@@ -26,7 +26,7 @@ export class ScatterChartVisualization extends G2VisualizationBase {
     this.viewContainerRef
   );
 
-  constructor(config: GraphConfig, private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef) {
+  constructor(private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef, config: GraphConfig) {
     super(config);
   }
 }

--- a/zeppelin-web-angular/src/app/visualizations/table/table-visualization.ts
+++ b/zeppelin-web-angular/src/app/visualizations/table/table-visualization.ts
@@ -31,7 +31,7 @@ export class TableVisualization extends Visualization<TableVisualizationComponen
     this.portalOutlet,
     this.viewContainerRef
   );
-  constructor(config: GraphConfig, private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef) {
+  constructor(private portalOutlet: CdkPortalOutlet, private viewContainerRef: ViewContainerRef, config: GraphConfig) {
     super(config);
   }
 

--- a/zeppelin-web-angular/tslint-rules/constructorParamsOrderRule.js
+++ b/zeppelin-web-angular/tslint-rules/constructorParamsOrderRule.js
@@ -1,0 +1,106 @@
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
+exports.__esModule = true;
+var ts = require("typescript");
+var Lint = require("tslint");
+var Rule = /** @class */ (function (_super) {
+    __extends(Rule, _super);
+    function Rule() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Rule.prototype.apply = function (sourceFile) {
+        return this.applyWithFunction(sourceFile, walk);
+    };
+    Rule.FAILURE_STRING = "Constructor parameters should be ordered: public, protected, private";
+    return Rule;
+}(Lint.Rules.AbstractRule));
+exports.Rule = Rule;
+function walk(ctx) {
+    var checkNode = function (node) {
+        if (ts.isConstructorDeclaration(node)) {
+            var params_1 = node.parameters;
+            if (params_1.length <= 1)
+                return;
+            var rankMap_1 = { public: 0, protected: 1, private: 2, none: 3 };
+            var getModifierRank_1 = function (param) { return rankMap_1[getModifier(param)]; };
+            var lastRank = -1;
+            var needFix = false;
+            for (var i = 0; i < params_1.length; i++) {
+                var currentRank = getModifierRank_1(params_1[i]);
+                if (currentRank < lastRank) {
+                    needFix = true;
+                    break;
+                }
+                lastRank = currentRank;
+            }
+            if (needFix) {
+                var sourceText_1 = node.getSourceFile().text;
+                // 파라미터 조각 추출
+                var paramSlices_1 = params_1.map(function (p, idx) {
+                    // 현재 파라미터 시작
+                    var start = p.getStart();
+                    // 다음 파라미터가 있으면 그 직전까지 포함
+                    // (즉, 현재 파라미터 끝 ~ 다음 파라미터 시작 사이의 ,와 공백/주석까지 포함)
+                    var end = idx < params_1.length - 1 ? params_1[idx + 1].getStart() : p.getEnd();
+                    var text = sourceText_1.slice(start, end);
+                    return { node: p, text: text };
+                });
+                // 정렬
+                var sorted = __spreadArrays(paramSlices_1).sort(function (a, b) { return getModifierRank_1(a.node) - getModifierRank_1(b.node); });
+                var startLine = ctx.sourceFile.getLineAndCharacterOfPosition(node.parameters.pos).line;
+                var endLine = ctx.sourceFile.getLineAndCharacterOfPosition(node.parameters.end).line;
+                var isMultiLine_1 = startLine !== endLine;
+                var indent_1 = sorted[0].text.replace(sorted[0].text.trim(), '');
+                // 조합
+                var fixText = sorted.map(function (s, index) {
+                    console.log(s.text);
+                    if (index === paramSlices_1.length - 1) {
+                        return s.text.replace(',', '');
+                    }
+                    if (s.text.includes(',')) {
+                        return s.text;
+                    }
+                    if (!s.text.includes('\n') && isMultiLine_1) {
+                        console.log('IN??');
+                        return s.text + ',' + indent_1;
+                    }
+                    return s.text + ', ';
+                }).join("").trim();
+                var fix = Lint.Replacement.replaceFromTo(params_1[0].getStart(), params_1[params_1.length - 1].getEnd(), fixText);
+                ctx.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
+            }
+        }
+        ts.forEachChild(node, checkNode);
+    };
+    ts.forEachChild(ctx.sourceFile, checkNode);
+}
+function getModifier(param) {
+    if (param.modifiers) {
+        if (param.modifiers.some(function (m) { return m.kind === ts.SyntaxKind.PublicKeyword; }))
+            return "public";
+        if (param.modifiers.some(function (m) { return m.kind === ts.SyntaxKind.ProtectedKeyword; }))
+            return "protected";
+        if (param.modifiers.some(function (m) { return m.kind === ts.SyntaxKind.PrivateKeyword; }))
+            return "private";
+    }
+    return "none";
+}

--- a/zeppelin-web-angular/tslint-rules/constructorParamsOrderRule.ts
+++ b/zeppelin-web-angular/tslint-rules/constructorParamsOrderRule.ts
@@ -1,0 +1,93 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static FAILURE_STRING = "Constructor parameters should be ordered: public, protected, private";
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithFunction(sourceFile, walk);
+  }
+}
+
+function walk(ctx: Lint.WalkContext<void>) {
+  const checkNode = (node: ts.Node) => {
+    if (ts.isConstructorDeclaration(node)) {
+      const params = node.parameters;
+      if (params.length <= 1) return;
+
+      const rankMap: Record<string, number> = { public: 0, protected: 1, private: 2, none: 3 };
+      const getModifierRank = (param: ts.ParameterDeclaration) => rankMap[getModifier(param)];
+
+      let lastRank = -1;
+      let needFix = false;
+      for (let i = 0; i < params.length; i++) {
+        const currentRank = getModifierRank(params[i]);
+        if (currentRank < lastRank) {
+          needFix = true;
+          break;
+        }
+        lastRank = currentRank;
+      }
+
+      if (needFix) {
+        const sourceText = node.getSourceFile().text;
+
+        // For keeping comment
+        const paramSlices = params.map((p, idx) => {
+          const start = p.getStart();
+
+          const end = idx < params.length - 1 ? params[idx + 1].getStart() : p.getEnd();
+
+          const text = sourceText.slice(start, end);
+          return { node: p, text };
+        });
+
+        // For sort
+        const sorted = [...paramSlices].sort(
+          (a, b) => getModifierRank(a.node) - getModifierRank(b.node)
+        );
+
+        const { line: startLine } = ctx.sourceFile.getLineAndCharacterOfPosition(node.parameters.pos);
+        const { line: endLine } = ctx.sourceFile.getLineAndCharacterOfPosition(node.parameters.end);
+        const isMultiLine = startLine !== endLine;
+        let indent = sorted[0].text.replace(sorted[0].text.trim(), '');
+
+        // For recombination
+        const fixText = sorted.map((s, index) => {
+          if (index === paramSlices.length - 1) {
+            return s.text.replace(',', '')
+          }
+
+          if (s.text.includes(',')) {
+            return s.text;
+          }
+
+          if (!s.text.includes('\n') && isMultiLine) {
+            return s.text + ',' + indent;
+          }
+
+          return s.text + ', ';
+        }).join("").trim();
+
+        const fix = Lint.Replacement.replaceFromTo(
+          params[0].getStart(),
+          params[params.length - 1].getEnd(),
+          fixText
+        );
+
+        ctx.addFailureAtNode(node, Rule.FAILURE_STRING, fix);
+      }
+    }
+    ts.forEachChild(node, checkNode);
+  };
+  ts.forEachChild(ctx.sourceFile, checkNode);
+}
+
+function getModifier(param: ts.ParameterDeclaration): string {
+  if (param.modifiers) {
+    if (param.modifiers.some(m => m.kind === ts.SyntaxKind.PublicKeyword)) return "public";
+    if (param.modifiers.some(m => m.kind === ts.SyntaxKind.ProtectedKeyword)) return "protected";
+    if (param.modifiers.some(m => m.kind === ts.SyntaxKind.PrivateKeyword)) return "private";
+  }
+  return "none";
+}

--- a/zeppelin-web-angular/tslint.json
+++ b/zeppelin-web-angular/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["node_modules/codelyzer", "node_modules/nz-tslint-rules"],
+  "rulesDirectory": ["node_modules/codelyzer", "node_modules/nz-tslint-rules", "tslint-rules"],
   "rules": {
     "nz-secondary-entry-imports": true,
     "banana-in-box": true,
@@ -137,6 +137,7 @@
     "use-isnan": true,
     "variable-name": [true, "ban-keywords", "allow-leading-underscore"],
     "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"],
-    "no-input-rename": true
+    "no-input-rename": true,
+    "constructor-params-order": true
   }
 }


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/zeppelin/pull/5045#discussion_r2300816684

Following above PR, I received feedback from a committer suggesting that constructor parameters should be ordered as public → protected → private.
I found it deeply but there was no existing TSLint rule for this, So I implemented a custom rule. 

It works as intended, and I ran lint --fix with the new rule and confirmed that it was applied correctly. The modified files are also included in this PR. 

If you want to test it just follow below command.

```sh
// Base Dir: ./zeppelin/zeppelin-web-angular
npm run lint
```
or
```sh
// Base Dir: ./zeppelin/zeppelin-web-angular
npx tslint -c tslint.json 'src/**/*.ts' --fix
```

You can build the lint rule file using the command below

```sh
// Base Dir: ./zeppelin/zeppelin-web-angular/tslint-rules
npx tsc constructorParamsOrderRule.ts
```



### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
* [[ZEPPELIN-6301](https://issues.apache.org/jira/browse/ZEPPELIN-6301)]

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
