### PR TITLE
[ZEPPELIN-6307] Rename fieldname in NewNoteRequest class

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -508,7 +508,7 @@ public class NotebookRestApi extends AbstractRestApi {
       defaultInterpreterGroup = zConf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_GROUP_DEFAULT);
     }
     String noteId = notebookService.createNote(
-            request.getName(),
+            request.getNotePath(),
             defaultInterpreterGroup,
             request.getAddingEmptyParagraph(),
             getServiceContext(),
@@ -571,7 +571,7 @@ public class NotebookRestApi extends AbstractRestApi {
     String newNoteName = null;
     String revisionId = null;
     if (request != null) {
-      newNoteName = request.getName();
+      newNoteName = request.getNotePath();
       revisionId = request.getRevisionId();
     }
     AuthenticationInfo subject = new AuthenticationInfo(authenticationService.getPrincipal());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
@@ -23,15 +23,14 @@ import java.util.List;
  */
 public class NewNoteRequest {
 
-  //TODO(zjffdu) rename it to be notePath instead of name
-  private final String name;
+  private final String notePath;
   private final String defaultInterpreterGroup;
   private final Boolean addingEmptyParagraph;
   private final List<NewParagraphRequest> paragraphs;
   private final String revisionId;
 
-  public NewNoteRequest(String name, String defaultInterpreterGroup, Boolean addingEmptyParagraph, List<NewParagraphRequest> paragraphs, String revisionId) {
-    this.name = name;
+  public NewNoteRequest(String notePath, String defaultInterpreterGroup, Boolean addingEmptyParagraph, List<NewParagraphRequest> paragraphs, String revisionId) {
+    this.notePath = notePath;
     this.defaultInterpreterGroup = defaultInterpreterGroup;
     this.addingEmptyParagraph = addingEmptyParagraph;
     this.paragraphs = paragraphs;
@@ -49,8 +48,8 @@ public class NewNoteRequest {
     return addingEmptyParagraph.booleanValue();
   }
 
-  public String getName() {
-    return name;
+  public String getNotePath() {
+    return notePath;
   }
 
   public String getDefaultInterpreterGroup() {


### PR DESCRIPTION
### What is this PR for?
This PR renames the field 'name' to 'notePath' in the NewNoteRequest class to better reflect its purpose. The field actually represents the note's path rather than just a name, making the code more semantically clear and addressing the TODO comment that requested this change.

### What type of PR is it?
Refactoring


### Todos
* [x] - Rename field 'name' to 'notePath' in NewNoteRequest class

### What is the Jira issue?
[ZEPPELIN-6307](https://issues.apache.org/jira/browse/ZEPPELIN-6307)

### How should this be tested?


### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
