### PR TITLE
[ZEPPELIN-6310] When paragraph to edit, word wrap doesn't work

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -157,6 +157,7 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
       scrollBeyondLastLine: false,
       contextmenu: false,
       matchBrackets: 'always',
+      wordWrap: 'on',
       scrollbar: {
         handleMouseWheel: false,
         alwaysConsumeMouseWheel: false


### PR DESCRIPTION
### What is this PR for?
**Description:**
You can check that in the Classic UI, word wrap is applied when editing an paragraph, but in the New UI it is not, which makes editing difficult. From a user’s perspective, the lack of word wrap can make editing both inconvenient and confusing, so this issue should be addressed. Also, in the case of .md files, word wrap is applied when the file is executed, but it is not applied when editing, which seems to cause an inconsistency.

**[Appropriate action - Classic UI]**

https://github.com/user-attachments/assets/064d883d-0b3e-44cb-9448-bc00848bae78

**[AS-IS]**

https://github.com/user-attachments/assets/3084b82a-a8fd-492f-8ef0-3fa421f92e99

**[TO-BE]**

https://github.com/user-attachments/assets/8b8db68b-9373-41d1-b091-57599b34a4f2

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* [[ZEPPELIN-6310](https://issues.apache.org/jira/browse/ZEPPELIN-6310)]

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N