### PR TITLE
[ZEPPELIN-6304] Changes to interpreter bindings are not reflected when reopening the binding settings

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
@@ -115,6 +115,9 @@ export class NotebookActionBarComponent extends MessageListenersManager implemen
       this.activatedExtension = 'hide';
     } else {
       this.activatedExtension = extension;
+      if (extension === 'interpreter') {
+        this.messageService.getInterpreterBindings(this.note.id);
+      }
     }
     this.activatedExtensionChange.emit(this.activatedExtension);
   }


### PR DESCRIPTION
### What is this PR for?
**Description:**
Changing the interpreter for a paragraph did not update the binding list area when clicking the `Interpreter Binding` button in the **action bar**. Although the server had the correct values, the client did not call the update function.

**[Appropriate action - Classic UI]**

https://github.com/user-attachments/assets/f2bbb602-056f-4f09-8015-e0268233f246

**[AS-IS]**

https://github.com/user-attachments/assets/38b41567-eccd-47b6-942d-afa603d86dff

**[TO-BE]**

https://github.com/user-attachments/assets/b9959eb8-5408-49fb-a9e5-15a725ca048a

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* [[ZEPPELIN-6304](https://issues.apache.org/jira/browse/ZEPPELIN-6304)]

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
