### PR TITLE
[ZEPPELIN-6309] Improve method by replacing JsonObject parameter

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfoSaving.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfoSaving.java
@@ -64,7 +64,7 @@ public class InterpreterInfoSaving implements JsonSerializable {
         for (InterpreterSetting interpreterSetting : infoSaving.interpreterSettings.values()) {
           JsonObject interpreterSettingJson = jsonObject.getAsJsonObject("interpreterSettings")
               .getAsJsonObject(interpreterSetting.getId());
-          List<String> users = InterpreterSetting.extractUsersFromJsonObject(interpreterSettingJson);
+          List<String> users = InterpreterSetting.extractUsersFromJsonString(interpreterSettingJson.toString());
           interpreterSetting.convertPermissionsFromUsersToOwners(users);
         }
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfoSaving.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfoSaving.java
@@ -62,9 +62,10 @@ public class InterpreterInfoSaving implements JsonSerializable {
 
       if (infoSaving != null && infoSaving.interpreterSettings != null) {
         for (InterpreterSetting interpreterSetting : infoSaving.interpreterSettings.values()) {
-          interpreterSetting.convertPermissionsFromUsersToOwners(
-                  jsonObject.getAsJsonObject("interpreterSettings")
-                          .getAsJsonObject(interpreterSetting.getId()));
+          JsonObject interpreterSettingJson = jsonObject.getAsJsonObject("interpreterSettings")
+              .getAsJsonObject(interpreterSetting.getId());
+          List<String> users = InterpreterSetting.extractUsersFromJsonObject(interpreterSettingJson);
+          interpreterSetting.convertPermissionsFromUsersToOwners(users);
         }
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -1026,7 +1026,7 @@ public class InterpreterSetting {
   }
 
   public static List<String> extractUsersFromJsonObject(JsonObject jsonObject) {
-    List<String> users = new ArrayList<>();
+    List<String> users = new LinkedList<>();
     if (jsonObject != null) {
       JsonObject option = jsonObject.getAsJsonObject("option");
       if (option != null) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -1016,22 +1016,29 @@ public class InterpreterSetting {
     t.start();
   }
 
-  //TODO(zjffdu) ugly code, should not use JsonObject as parameter. not readable
-  public void convertPermissionsFromUsersToOwners(JsonObject jsonObject) {
+  public void convertPermissionsFromUsersToOwners(List<String> users) {
+    if (users != null && !users.isEmpty()) {
+      if (this.option.getOwners() == null) {
+        this.option.owners = new LinkedList<>();
+      }
+      this.option.getOwners().addAll(users);
+    }
+  }
+
+  public static List<String> extractUsersFromJsonObject(JsonObject jsonObject) {
+    List<String> users = new ArrayList<>();
     if (jsonObject != null) {
       JsonObject option = jsonObject.getAsJsonObject("option");
       if (option != null) {
-        JsonArray users = option.getAsJsonArray("users");
-        if (users != null) {
-          if (this.option.getOwners() == null) {
-            this.option.owners = new LinkedList<>();
-          }
-          for (JsonElement user : users) {
-            this.option.getOwners().add(user.getAsString());
+        JsonArray usersArray = option.getAsJsonArray("users");
+        if (usersArray != null) {
+          for (JsonElement userElement : usersArray) {
+            users.add(userElement.getAsString());
           }
         }
       }
     }
+    return users;
   }
 
   // For backward compatibility of interpreter.json format after ZEPPELIN-2403

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -1025,20 +1025,27 @@ public class InterpreterSetting {
     }
   }
 
-  public static List<String> extractUsersFromJsonObject(JsonObject jsonObject) {
-    List<String> users = new LinkedList<>();
-    if (jsonObject != null) {
-      JsonObject option = jsonObject.getAsJsonObject("option");
-      if (option != null) {
-        JsonArray usersArray = option.getAsJsonArray("users");
-        if (usersArray != null) {
-          for (JsonElement userElement : usersArray) {
-            users.add(userElement.getAsString());
-          }
-        }
-      }
+  private static class InterpreterSettingData {
+    private OptionData option;
+    
+    private static class OptionData {
+      private List<String> users;
     }
-    return users;
+  }
+
+  public static List<String> extractUsersFromJsonString(String jsonString) {
+    if (jsonString == null || jsonString.trim().isEmpty()) {
+      return new LinkedList<>();
+    }
+    
+    Gson gson = new Gson();
+    InterpreterSettingData data = gson.fromJson(jsonString, InterpreterSettingData.class);
+    
+    if (data != null && data.option != null && data.option.users != null) {
+      return new LinkedList<>(data.option.users);
+    }
+    
+    return new LinkedList<>();
   }
 
   // For backward compatibility of interpreter.json format after ZEPPELIN-2403

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/ConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/ConfigStorage.java
@@ -27,6 +27,7 @@ import org.apache.zeppelin.notebook.NotebookAuthorizationInfoSaving;
 import org.apache.zeppelin.util.ReflectionUtils;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Interface for storing zeppelin configuration.
@@ -78,9 +79,10 @@ public abstract class ConfigStorage {
       // enable/disable option on GUI).
       // previously created setting should turn this feature on here.
       interpreterSetting.getOption();
-      interpreterSetting.convertPermissionsFromUsersToOwners(
-          jsonObject.getAsJsonObject("interpreterSettings")
-              .getAsJsonObject(interpreterSetting.getId()));
+      JsonObject interpreterSettingJson = jsonObject.getAsJsonObject("interpreterSettings")
+          .getAsJsonObject(interpreterSetting.getId());
+      List<String> users = InterpreterSetting.extractUsersFromJsonObject(interpreterSettingJson);
+      interpreterSetting.convertPermissionsFromUsersToOwners(users);
     }
     return infoSaving;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/ConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/ConfigStorage.java
@@ -27,8 +27,8 @@ import org.apache.zeppelin.notebook.NotebookAuthorizationInfoSaving;
 import org.apache.zeppelin.util.ReflectionUtils;
 
 import java.io.IOException;
-import java.util.List;
 
+import java.util.List;
 /**
  * Interface for storing zeppelin configuration.
  *

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/ConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/ConfigStorage.java
@@ -70,7 +70,6 @@ public abstract class ConfigStorage {
   public abstract void saveCredentials(String credentials) throws IOException;
 
   protected InterpreterInfoSaving buildInterpreterInfoSaving(String json) {
-    //TODO(zjffdu) This kind of post processing is ugly.
     JsonObject jsonObject = JsonParser.parseString(json).getAsJsonObject();
     InterpreterInfoSaving infoSaving = InterpreterInfoSaving.fromJson(json);
     for (InterpreterSetting interpreterSetting : infoSaving.interpreterSettings.values()) {
@@ -81,7 +80,7 @@ public abstract class ConfigStorage {
       interpreterSetting.getOption();
       JsonObject interpreterSettingJson = jsonObject.getAsJsonObject("interpreterSettings")
           .getAsJsonObject(interpreterSetting.getId());
-      List<String> users = InterpreterSetting.extractUsersFromJsonObject(interpreterSettingJson);
+      List<String> users = InterpreterSetting.extractUsersFromJsonString(interpreterSettingJson.toString());
       interpreterSetting.convertPermissionsFromUsersToOwners(users);
     }
     return infoSaving;


### PR DESCRIPTION
### What is this PR for?
Refactored the `convertPermissionsFromUsersToOwners` method in InterpreterSetting.java to improve code readability and maintainability by separating JSON parsing logic from business logic, addressing the TODO comment that identified this as "ugly code".

### What type of PR is it?
Refactoring


### Todos
  * [x] - Refactor convertPermissionsFromUsersToOwners method to remove JsonObject parameter
  * [x] - Extract JSON parsing logic into separate static helper method
  * [x] - Update all callers to use new method signature
  

### What is the Jira issue?
[ZEPPELIN-6309](https://issues.apache.org/jira/browse/ZEPPELIN-6309)

### How should this be tested?


### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
