### PR TITLE
[ZEPPELIN-6318] Add .nvmrc to set node v16.20.2 for Zeppelin client

### DIFF
--- a/zeppelin-web-angular/.nvmrc
+++ b/zeppelin-web-angular/.nvmrc
@@ -1,1 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 16.20.2

--- a/zeppelin-web/.nvmrc
+++ b/zeppelin-web/.nvmrc
@@ -1,1 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 16.20.2


### PR DESCRIPTION
### What is this PR for?
Using a `.nvmrc` file allows people using `nvm` to easily specify and switch to the desired Node version. In my work, I often use different Node versions for Zeppelin and other projects, and switching between them every time can be cumbersome. Setting up a `.nvmrc` would automate this process, making it much more convenient. It would also allow `nvm` users to not worry about the Node version, thereby reducing unnecessary overhead.

https://github.com/apache/superset/blob/master/docs/.nvmrc

I looked at other Apache projects and found that Superset already uses a `.nvmrc` file. Therefore, it would be beneficial to apply the same to Zeppelin. And in this PR, I pinned Node to version **16.20.2** for both **zeppelin-web** and **zeppelin-web-angular**, the latest release of Node 16, using `.nvmrc`.


### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
* [[ZEPPELIN-6318](https://issues.apache.org/jira/browse/ZEPPELIN-6318)]

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
