### PR TITLE
[ZEPPELIN-6306] Prevent NPE in StaticRepl by fail-fast JavaCompiler check

### DIFF
--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -49,6 +49,12 @@ public class StaticRepl {
 
   public static String execute(String generatedClassName, String code) throws Exception {
 
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    if (compiler == null) {
+      throw new Exception(
+          "Java compiler not available. Make sure Zeppelin is running on JDK (not JRE).");
+    }
+
     // Java parsing
     JavaProjectBuilder builder = new JavaProjectBuilder();
     JavaSource src = builder.addSource(new StringReader(code));
@@ -100,7 +106,6 @@ public class StaticRepl {
     System.setOut(newOut);
     System.setErr(newErr);
 
-    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
     CompilationTask task = compiler.getTask(null, null, diagnostics, null, null, compilationUnits);
 
@@ -144,7 +149,7 @@ public class StaticRepl {
         return baosOut.toString();
 
       } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-          | InvocationTargetException e) {
+               | InvocationTargetException e) {
         LOGGER.error("Exception in Interpreter while execution", e);
         System.err.println(e);
         e.printStackTrace(newErr);
@@ -165,6 +170,7 @@ public class StaticRepl {
 }
 
 class JavaSourceFromString extends SimpleJavaFileObject {
+
   final String code;
 
   JavaSourceFromString(String name, String code) {

--- a/java/src/test/java/org/apache/zeppelin/java/JavaInterpreterTest.java
+++ b/java/src/test/java/org/apache/zeppelin/java/JavaInterpreterTest.java
@@ -51,6 +51,12 @@ class JavaInterpreterTest {
   }
 
   @Test
+  void testJDKCompilerAvailability() {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    assertNotNull(compiler, "Compiler should not be null");
+  }
+
+  @Test
   void testStaticRepl() {
 
     StringWriter writer = new StringWriter();

--- a/java/src/test/java/org/apache/zeppelin/java/JavaInterpreterTest.java
+++ b/java/src/test/java/org/apache/zeppelin/java/JavaInterpreterTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.zeppelin.java;
 
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.junit.jupiter.api.AfterAll;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;


### PR DESCRIPTION
### What is this PR for?
- ToolProvider.getSystemJavaCompiler() can return null in JRE environments.
- Added a fail-fast null check in StaticRepl to throw a clear exception early.
- Updated unit test to reflect this behavior.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* [ZEPPELIN-6306](https://issues.apache.org/jira/browse/ZEPPELIN-6306)

### How should this be tested?
*  Run the existing unit test `testJDKCompilerAvailability()` to ensure the compiler is available in JDK.
* Run all Zeppelin unit tests to confirm no regressions.
### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
