### PR TITLE
[ZEPPELIN-6319] Fixing unsupported wildcard path expansion in zeppelin-web-angular

### DIFF
--- a/zeppelin-web-angular/package.json
+++ b/zeppelin-web-angular/package.json
@@ -6,15 +6,15 @@
     "ng": "./node_modules/.bin/ng",
     "start": "ng serve --proxy-config proxy.conf.js --extra-webpack-config webpack.partial.js",
     "build": "ng build --prod --extra-webpack-config webpack.partial.js",
-    "build:tslint-rules": "tsc tslint-rules/*.ts --types node",
+    "build:tslint-rules": "tsc -p tslint-rules/tsconfig.json",
     "build:projects": "npm run build-project:sdk && npm run build-project:vis && npm run build-project:helium",
     "build-helium-vis-example": " ng build --project helium-vis-example",
     "build-project:sdk": " ng build --project zeppelin-sdk",
     "build-project:vis": " ng build --project zeppelin-visualization",
     "build-project:helium": "ng build --project zeppelin-helium",
     "test": "ng test",
-    "lint": "ng lint && tslint tslint-rules/*.ts && prettier --check \"**/*.{ts,js,json,css,html}\"",
-    "lint:fix": "ng lint --fix && tslint --fix tslint-rules/*.ts && prettier --write \"**/*.{ts,js,json,css,html}\"",
+    "lint": "ng lint && tslint -p tslint-rules/tsconfig.json && prettier --check \"**/*.{ts,js,json,css,html}\"",
+    "lint:fix": "ng lint --fix && tslint --fix -p tslint-rules/tsconfig.json && prettier --write \"**/*.{ts,js,json,css,html}\"",
     "e2e": "ng e2e"
   },
   "engines": {

--- a/zeppelin-web-angular/tslint-rules/tsconfig.json
+++ b/zeppelin-web-angular/tslint-rules/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
### What is this PR for?
Windows cmd and does not support wildcard path expansion, which causes errors like the one below.
<img width="954" height="190" alt="image" src="https://github.com/user-attachments/assets/3356609d-d2a6-4135-8c35-75d35df54291" />

This PR fixes the issue by replacing the glob pattern path argument with a specific `tsconfig.json` file for `tslint-rules/`.



### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6319

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
