### PR TITLE
[ZEPPELIN-6327] Fix wrong order of the arguments for Visualization components

### DIFF
--- a/zeppelin-web-angular/projects/zeppelin-visualization/src/visualization.ts
+++ b/zeppelin-web-angular/projects/zeppelin-visualization/src/visualization.ts
@@ -10,7 +10,8 @@
  * limitations under the License.
  */
 
-import { ComponentRef } from '@angular/core';
+import { CdkPortalOutlet } from '@angular/cdk/portal';
+import { ComponentRef, ViewContainerRef } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { GraphConfig } from '@zeppelin/sdk';
@@ -44,4 +45,8 @@ export abstract class Visualization<T = any> {
   getConfig() {
     return this.config;
   }
+}
+
+export interface VisualizationConstructor<T = any> {
+  new (portalOutlet: CdkPortalOutlet, viewContainerRef: ViewContainerRef, config: GraphConfig): Visualization<T>;
 }

--- a/zeppelin-web-angular/projects/zeppelin-visualization/src/visualization.ts
+++ b/zeppelin-web-angular/projects/zeppelin-visualization/src/visualization.ts
@@ -17,7 +17,7 @@ import { Subject } from 'rxjs';
 import { GraphConfig } from '@zeppelin/sdk';
 import { Transformation } from './transformation';
 
-// tslint:disable-next-line
+// tslint:disable-next-line:no-any
 export abstract class Visualization<T = any> {
   // tslint:disable-next-line
   transformed: any;
@@ -47,6 +47,9 @@ export abstract class Visualization<T = any> {
   }
 }
 
-export interface VisualizationConstructor<T = any> {
-  new (portalOutlet: CdkPortalOutlet, viewContainerRef: ViewContainerRef, config: GraphConfig): Visualization<T>;
-}
+// tslint:disable-next-line:no-any
+export type VisualizationConstructor<T = any> = new (
+  portalOutlet: CdkPortalOutlet,
+  viewContainerRef: ViewContainerRef,
+  config: GraphConfig
+) => Visualization<T>;

--- a/zeppelin-web-angular/src/app/pages/workspace/share/result/result.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/share/result/result.component.ts
@@ -16,7 +16,6 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  ComponentFactoryResolver,
   EventEmitter,
   Injector,
   Input,
@@ -52,9 +51,14 @@ import {
   HeliumClassicVisualizationConstructor,
   HeliumVisualizationBundle
 } from '@zeppelin/interfaces';
-import { DynamicTemplate, HeliumService, NgZService, RuntimeCompilerService } from '@zeppelin/services';
-import { ClassicVisualizationService } from '@zeppelin/services/classic-visualization.service';
-import { TableData, Visualization } from '@zeppelin/visualization';
+import {
+  ClassicVisualizationService,
+  DynamicTemplate,
+  HeliumService,
+  NgZService,
+  RuntimeCompilerService
+} from '@zeppelin/services';
+import { TableData, Visualization, VisualizationConstructor } from '@zeppelin/visualization';
 import {
   AreaChartVisualization,
   BarChartVisualization,
@@ -68,7 +72,6 @@ interface VisualizationItem {
   id: string;
   name: string;
   changeSubscription: Subscription | null;
-  componentFactoryResolver?: ComponentFactoryResolver;
 }
 
 interface ClassicVisualizationItem extends VisualizationItem {
@@ -81,8 +84,7 @@ interface ClassicVisualizationItem extends VisualizationItem {
 interface ModernVisualizationItem extends VisualizationItem {
   isClassic: false;
   icon: string;
-  // tslint:disable-next-line:no-any
-  Class: any;
+  Class: VisualizationConstructor;
   instance: Visualization | undefined;
 }
 
@@ -431,12 +433,7 @@ export class NotebookParagraphResultComponent implements OnInit, AfterViewInit, 
         return; // Exit early for classic visualizations
       } else {
         // Modern visualization
-        const classicVisInstance = new visualizationItem.Class(
-          config.graph,
-          this.portalOutlet,
-          this.viewContainerRef,
-          visualizationItem.componentFactoryResolver
-        ) as Visualization;
+        const classicVisInstance = new visualizationItem.Class(this.portalOutlet, this.viewContainerRef, config.graph);
         visualizationItem.instance = classicVisInstance;
         visualizationItem.changeSubscription = classicVisInstance.configChanged().subscribe(c => {
           if (!this.config) {


### PR DESCRIPTION
### What is this PR for?
Visualizations are not working because the constructor arguments were passed in the wrong order.
Since using `any` made this error hard to detect, I replaced it with specific types.
(Related to #5053)

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6327

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
