### PR TITLE
[ZEPPELIN-6336] Fix failing zengine tests caused by invalid interpreters.json

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfoSaving.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfoSaving.java
@@ -93,7 +93,20 @@ public class InterpreterInfoSaving implements JsonSerializable {
   }
 
   public static InterpreterInfoSaving fromJson(String json) {
-    return GSON.fromJson(json, InterpreterInfoSaving.class);
+    InterpreterInfoSaving interpreterInfoSaving = GSON.fromJson(json, InterpreterInfoSaving.class);
+    if (interpreterInfoSaving.interpreterSettings != null) {
+      for (Map.Entry<String, InterpreterSetting> entry : interpreterInfoSaving.interpreterSettings.entrySet()) {
+        String key = entry.getKey();
+        InterpreterSetting setting = entry.getValue();
+        String id = setting == null ? null : setting.getId();
+        if (!key.equals(id)) {
+          LOGGER.error("Invalid interpreterSettings: key '{}' does not match inner id '{}'.", key, id);
+          throw new IllegalArgumentException(
+              "interpreterSettings key '" + key + "' does not match inner id '" + id + "'");
+        }
+      }
+    }
+    return interpreterInfoSaving;
   }
 
   // kept for backward compatibility: no custom serializers are needed currently

--- a/zeppelin-zengine/src/test/resources/conf/interpreter.json
+++ b/zeppelin-zengine/src/test/resources/conf/interpreter.json
@@ -69,6 +69,7 @@
     },
 
     "2C4BJDRRZ" : {
+      "id": "2C4BJDRRZ",
       "group": "mock1",
       "name": "mock1",
       "className": "org.apache.zeppelin.interpreter.mock.MockInterpreter1",
@@ -87,6 +88,7 @@
     },
 
     "2C3PTPMUH" : {
+      "id": "2C3PTPMUH",
       "group": "mock2",
       "name": "mock2",
       "className": "org.apache.zeppelin.interpreter.mock.MockInterpreter2",
@@ -105,6 +107,7 @@
     },
 
     "2C5DCRVGM" : {
+      "id": "2C5DCRVGM",
       "group": "mock_resource_pool",
       "name": "mock_resource_pool",
       "className": "org.apache.zeppelin.interpreter.remote.mock.MockInterpreterResourcePool",
@@ -123,6 +126,7 @@
     },
 
     "2C5EERVGA" : {
+      "id": "2C5EERVGA",
       "group": "config_test",
       "name": "config_test",
       "className": "org.apache.zeppelin.interpreter.mock.MockInterpreter1",


### PR DESCRIPTION
### What is this PR for?
Tests in the `zeppelin-zengine` module were failing. The main reason was that the `interpreter.json` in test resources were invalid: the value object did not have an `id` field matching its corresponding key.
As a result, the deserialized `InterpreterSetting` instance had an auto-genarated `id` field, causing the key and value.id to be inconsistent.
Before #5063, invalid settings were simply skipped. However, after that change, they caused a NPE.

This PR fixes the invalid JSON files and adds minor validation logic in the deserialization method so that such issues can be detected early by users.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6335

### How should this be tested?
* Check `core-modules` - `zeppelin-zengine` tests in CI


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
