### PR TITLE
[ZEPPELIN-6338] Allow separate frontend modules to use different Node/NPM versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,7 @@
     <scalatest.version>3.2.19</scalatest.version>
     <scalacheck.version>1.18.1</scalacheck.version>
 
-    <!-- frontend maven plugin related versions-->
-    <node.version>v16.20.2</node.version>
-    <npm.version>8.19.4</npm.version>
+    <!-- frontend maven plugin version-->
     <plugin.frontend.version>1.12.1</plugin.frontend.version>
 
     <!-- common library versions -->

--- a/zeppelin-web-angular/pom.xml
+++ b/zeppelin-web-angular/pom.xml
@@ -39,8 +39,10 @@
     <!--plugin versions-->
     <plugin.frontend.nodeDownloadRoot>https://nodejs.org/dist/</plugin.frontend.nodeDownloadRoot>
     <plugin.frontend.npmDownloadRoot>https://registry.npmjs.org/npm/-/</plugin.frontend.npmDownloadRoot>
+    <node.version>v16.20.2</node.version>
+    <npm.version>8.19.4</npm.version>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.apache.zeppelin</groupId>
@@ -63,7 +65,7 @@
 
       <plugin>
         <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>        
+        <artifactId>frontend-maven-plugin</artifactId>
         <configuration>
           <nodeDownloadRoot>${plugin.frontend.nodeDownloadRoot}</nodeDownloadRoot>
           <npmDownloadRoot>${plugin.frontend.npmDownloadRoot}</npmDownloadRoot>
@@ -236,7 +238,7 @@
       </plugin>
     </plugins>
   </build>
-    
+
   <profiles>
     <profile>
       <id>web-e2e</id>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -39,6 +39,8 @@
     <!--plugin versions-->
     <plugin.frontend.nodeDownloadRoot>https://nodejs.org/dist/</plugin.frontend.nodeDownloadRoot>
     <plugin.frontend.npmDownloadRoot>https://registry.npmjs.org/npm/-/</plugin.frontend.npmDownloadRoot>
+    <node.version>v16.20.2</node.version>
+    <npm.version>8.19.4</npm.version>
     <!-- the scope of the Hadoop dependencies is the same as for the other Zeppelin components -->
     <hadoop.deps.scope>test</hadoop.deps.scope>
   </properties>


### PR DESCRIPTION
### What is this PR for?
Moved the `node.version` and `npm.version` properties from the parent `pom.xml` to each module's `pom.xml`.
This allows `zeppelin-web` and `zeppelin-web-angular` to manage their Node/NPM versions independently.

Note: Each module installs and manages its own Node/NPM, so this change simply makes that independence explicit without adding extra maintenance burden or increasing package size.

### What type of PR is it?
Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6338

### How should this be tested?
Check CIs if Node and npm is installed for both modules.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
