### PR TITLE
[ZEPPELIN-6350] Fix Selenium test by Replacing Firefox with Edge

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -104,28 +104,32 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      ZEPPELIN_SELENIUM_BROWSER: firefox
+      ZEPPELIN_SELENIUM_BROWSER: "edge"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Firefox (non-snap) and geckodriver
-        run: |
-          sudo snap remove firefox || true
-          sudo add-apt-repository -y ppa:mozillateam/ppa
-          sudo tee -a /etc/apt/preferences.d/mozilla-firefox <<EOF
-          Package: *
-          Pin: release o=LP-PPA-mozillateam
-          Pin-Priority: 1001
-          EOF
-          sudo apt-get update
-          sudo apt-get install -y firefox
-          GECKODRIVER_VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
-          wget -q https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
-          tar -xzf geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz
-          chmod +x geckodriver
-          sudo mv geckodriver /usr/local/bin/
-          geckodriver --version
-          firefox --version
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+      - name: Set up Edge browser
+        uses: browser-actions/setup-edge@v1
+      - name: Print Edge version
+        run: msedgedriver --version
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/zeppelin/
+            ~/.spark-dist
+            ~/.cache
+          key: ${{ runner.os }}-zeppelin-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-zeppelin-
       - name: Setup conda environment with python 3.9 and R
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -136,19 +140,15 @@ jobs:
           channel-priority: strict
           auto-activate-base: false
           use-mamba: true
+      - name: Make IRkernel available to Jupyter
+        run: |
+          R -e "IRkernel::installspec()"
       - name: Install Environment
         run: |
           ./mvnw clean install -DskipTests -am -pl zeppelin-integration -Pweb-classic -Pintegration -Pspark-scala-2.12 -Pspark-3.5 -Pweb-dist ${MAVEN_ARGS}
-      - name: Print browser version
+      - name: run tests
         run: |
-          echo "Firefox version:"
-          firefox --version
-          echo "GeckoDriver version:"
-          geckodriver --version
-      - name: Run integration tests with Firefox
-        run: |
-          xvfb-run --auto-servernum --server-args="-screen 0 1600x1024x16" \
-            ./mvnw verify -DfailIfNoTests=false \
-            -pl zeppelin-integration \
-            -Pweb-classic -Pintegration -Pspark-scala-2.12 -Pspark-3.5 -Pweb-dist -Pusing-source-tree \
-            ${MAVEN_ARGS}
+          xvfb-run --auto-servernum --server-args="-screen 0 1600x1024x16" ./mvnw verify -DfailIfNoTests=false -pl zeppelin-integration -Pweb-classic -Pintegration -Pspark-scala-2.12 -Pspark-3.5 -Pweb-dist -Pusing-source-tree ${MAVEN_ARGS}
+      - name: Print zeppelin logs
+        if: always()
+        run: if [ -d "logs" ]; then cat logs/*; fi

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -34,6 +34,7 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
@@ -89,6 +90,14 @@ public class WebDriverManager implements Closeable {
         return null;
       }
     };
+    Supplier<WebDriver> edgeDriverSupplier = () -> {
+      try {
+        return new EdgeDriver();
+      } catch (Exception e) {
+        LOG.error("Exception in WebDriverManager while EdgeDriver ", e);
+        return null;
+        }
+    };
     Supplier<WebDriver> firefoxDriverSupplier = () -> {
       try {
         return getFirefoxDriver();
@@ -111,6 +120,9 @@ public class WebDriverManager implements Closeable {
       case "chrome":
         driver = chromeDriverSupplier.get();
         break;
+      case "edge":
+        driver = edgeDriverSupplier.get();
+        break;
       case "firefox":
         driver = firefoxDriverSupplier.get();
         break;
@@ -118,7 +130,7 @@ public class WebDriverManager implements Closeable {
         driver = safariDriverSupplier.get();
         break;
       default:
-        driver = Stream.of(chromeDriverSupplier, firefoxDriverSupplier, safariDriverSupplier)
+        driver = Stream.of(chromeDriverSupplier, edgeDriverSupplier, firefoxDriverSupplier, safariDriverSupplier)
             .map(Supplier::get)
             .filter(Objects::nonNull)
             .findFirst()


### PR DESCRIPTION
### What is this PR for?
This PR stabilizes the `test-selenium...` job by switching the Selenium browser from Firefox to Microsoft Edge.
In #4941, we worked around a Linux ChromeDriver issue (https://github.com/SeleniumHQ/selenium/issues/15358) by moving from Chrome to Firefox, but that workaround also seems to be not working well.

I use Edge driver instead, since it does not have flakiness like Firefox driver and is more aligned with Chrome since it is also based on Chromium.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
[[ZEPPELIN-6350]](https://issues.apache.org/jira/browse/ZEPPELIN-6350)

### How should this be tested?
- Check `test-selenium...` job in `frontend`

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
