### PR TITLE
[CI-Hotfix] Remove not allowed action in Selenium test

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -118,12 +118,12 @@ jobs:
           sudo apt-get install -y microsoft-edge-stable
       - name: Install msedgedriver
         run: |
-          EDGE_VERSION=$(microsoft-edge --version | grep -oP '\d+\.\d+\.\d+\.\d+')
-          DRIVER_VERSION=$(curl -s "https://msedgedriver.azureedge.net/LATEST_STABLE")
-          curl -L "https://msedgedriver.azureedge.net/${DRIVER_VERSION}/edgedriver_linux64.zip" -o edgedriver.zip
-          unzip edgedriver.zip
+          EDGE_VERSION=$(microsoft-edge --version | awk '{print $3}')
+          wget -q "https://msedgedriver.microsoft.com/${EDGE_VERSION}/edgedriver_linux64.zip" -O edgedriver.zip
+          unzip -q edgedriver.zip
           sudo mv msedgedriver /usr/local/bin/
           sudo chmod +x /usr/local/bin/msedgedriver
+          rm edgedriver.zip
       - name: Print Edge version
         run: msedgedriver --version
       - name: Set up JDK 11

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -110,8 +110,20 @@ jobs:
         uses: actions/checkout@v4
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
-      - name: Set up Edge browser
-        uses: browser-actions/setup-edge@v1
+      - name: Install Microsoft Edge
+        run: |
+          curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-edge.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-edge.gpg] https://packages.microsoft.com/repos/edge stable main" | sudo tee /etc/apt/sources.list.d/microsoft-edge.list
+          sudo apt-get update
+          sudo apt-get install -y microsoft-edge-stable
+      - name: Install msedgedriver
+        run: |
+          EDGE_VERSION=$(microsoft-edge --version | grep -oP '\d+\.\d+\.\d+\.\d+')
+          DRIVER_VERSION=$(curl -s "https://msedgedriver.azureedge.net/LATEST_STABLE")
+          curl -L "https://msedgedriver.azureedge.net/${DRIVER_VERSION}/edgedriver_linux64.zip" -o edgedriver.zip
+          unzip edgedriver.zip
+          sudo mv msedgedriver /usr/local/bin/
+          sudo chmod +x /usr/local/bin/msedgedriver
       - name: Print Edge version
         run: msedgedriver --version
       - name: Set up JDK 11


### PR DESCRIPTION
I attempted to create a related JIRA issue, but the Apache JIRA site isn't working for an hour. Therefore, I’m proceeding without creating the issue.

### What is this PR for?
Currently, our CI workflow uses browser-actions/setup-edge@v1 to install Microsoft Edge. However, this action is not allowed in the apache/zeppelin repository because only actions from approved/verified sources can be used.

<img width="2109" height="241" alt="image" src="https://github.com/user-attachments/assets/28b0e90a-ffaf-41b4-9c25-495088a20963" />

To resolve this, I removed the external action and replace it with a direct installation step.

### What type of PR is it?
Bug Fix


### How should this be tested?
- Check if CI works

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
