### PR TITLE
[ZEPPELIN-6385] Refactor StringsCompleter to use method reference for Comparator

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/completer/StringsCompleter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/completer/StringsCompleter.java
@@ -28,12 +28,7 @@ import jline.internal.Preconditions;
  * Case-insensitive completer for a set of strings.
  */
 public class StringsCompleter implements Completer {
-  private final SortedSet<String> strings = new TreeSet<>(new Comparator<String>() {
-    @Override
-    public int compare(String o1, String o2) {
-      return o1.compareToIgnoreCase(o2);
-    }
-  });
+  private final SortedSet<String> strings = new TreeSet<>(String::compareToIgnoreCase);
 
   public StringsCompleter() {
   }


### PR DESCRIPTION
### What is this PR for?

This PR refactors the anonymous Comparator implementation in StringsCompleter to use a method reference (`String::compareToIgnoreCase`).
The change simplifies the code, improves readability, and aligns the class with modern Java best practices.

### What type of PR is it?
Refactoring

### Todos
* [x] - Replace anonymous Comparator<String> class with method reference.

### What is the Jira issue?
* [[ZEPPELIN-6385]](https://issues.apache.org/jira/browse/ZEPPELIN-6385)

### How should this be tested?

Since the expected behavior remains unchanged, no additional tests are required.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
