### PR TITLE
[ZEPPELIN-6394] Fix concurrent file write issue when saving interpreter settings

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -359,7 +359,7 @@ public class InterpreterSettingManager implements NoteEventListener {
     }
   }
 
-  public void saveToFile() throws IOException {
+  public synchronized void saveToFile() throws IOException {
     InterpreterInfoSaving info = new InterpreterInfoSaving();
     info.interpreterSettings = new HashMap<>(interpreterSettings);
     info.interpreterRepositories = interpreterRepositories;


### PR DESCRIPTION

### What is this PR for?

Fix concurrent case throws java.nio.file.NoSuchFileException

https://github.com/apache/zeppelin/blob/8251dc4e013cde02879d186240155da8f996bdb7/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java#L1011-L1015

<img width="1959" height="956" alt="3a885fb1-f192-4693-94d1-a7eef140d030" src="https://github.com/user-attachments/assets/f01d7ef0-2b84-4ad9-ba28-67ea011c135c" />

#### Problem
When multiple interpreters download dependencies simultaneously during startup or other cases, the saveToFile() method can be called concurrently by multiple threads. This happens because loadInterpreterDependencies() spawns asynchronous threads that call saveToFile() when dependency download completes.

#### Solution
Add synchronized keyword to InterpreterSettingManager.saveToFile() method to ensure thread-safe file operations. This prevents multiple threads from writing to the configuration file simultaneously.

#### Impact
- Startup: Multiple interpreters downloading dependencies will serialize their save operations, ensuring data consistency
- Runtime: All file save operations (interpreter settings, repositories) are protected from race conditions
- Performance: Minimal impact as file save operations are fast and infrequent relative to dependency download time
 

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6394

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
