### PR TITLE
[ZEPPELIN-6395] Fix NumberFormatException for numeric interpreter properties in New UI

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/interpreter/item/item.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/interpreter/item/item.component.ts
@@ -95,7 +95,7 @@ export class InterpreterItemComponent extends DestroyHookComponent implements On
       .forEach((e: any) => {
         const { key, value, type } = e;
         properties[key] = {
-          value,
+          value: value.toString(),
           type,
           name: key
         };


### PR DESCRIPTION
### What is this PR for?

#### Problem:

The New UI (Angular) saves numeric interpreter properties as JavaScript number types, which get deserialized to Java Double by Gson. When these properties are converted to strings (e.g., 60000.0), parsing them as Long or Integer fails with NumberFormatException.

#### Solution:

Convert all property values to strings in the New UI before sending to the backend, matching the behavior of the Old UI which uses strings for all property values.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6395

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)



### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
