### PR TITLE
[ZEPPELIN-6397] Bump Testcontainers version to 1.21.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <plugin.source.version>3.2.1</plugin.source.version>
     <plugin.os.version>1.4.1.Final</plugin.os.version>
 
-    <testcontainers.version>1.19.0</testcontainers.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
 
     <MaxMetaspace>512m</MaxMetaspace>
 


### PR DESCRIPTION
### What is this PR for?

This PR bumps the testcontainers minor/patch versions.

<img width="2156" height="124" alt="image" src="https://github.com/user-attachments/assets/1db7118f-98f8-490f-863c-dc9eecc6e7dd" />

The interpreter-test-non-core job has been failing intermittently. Based on the error pattern, this appears related to a compatibility issue between older Testcontainers versions and newer Docker Engine APIs (see: https://github.com/testcontainers/testcontainers-java/issues/11212).

Testcontainers released a patch to address this, so this PR updates Testcontainers to 1.21.4 (release notes: https://github.com/testcontainers/testcontainers-java/releases/tag/1.21.4).

### What type of PR is it?
Bug Fix

### What is the Jira issue?[
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6397

### How should this be tested?
Check `interpreter-test-non-core` job.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
