### PR TITLE
[ZEPPELIN-6402] Update copyright year to 2026 in NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Zeppelin
-Copyright 2015 - 2025 The Apache Software Foundation
+Copyright 2015 - 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).


### PR DESCRIPTION
### What is this PR for?
This PR updates the copyright year range in the NOTICE file from 2015-2025 to 2015-2026 to reflect ongoing development and contributions in 2026.

### What type of PR is it?
Documentation

### Todos
* [x] - Update copyright year in NOTICE file

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6402

### How should this be tested?
* Verify that the NOTICE file contains the updated copyright year range "2015 - 2026"
* Confirm that no other changes were made to the NOTICE file

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.