### PR TITLE
[ZEPPELIN-6403] Fix deprecated auto-activate-base parameter in GitHub Actions

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -75,7 +75,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
         run: |
@@ -125,7 +125,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: verify interpreter
         run: ./mvnw verify -am -pl ${INTERPRETERS} ${MAVEN_ARGS}
@@ -167,7 +167,7 @@ jobs:
           python-version: ${{ matrix.python }}
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
         run: |
@@ -222,7 +222,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
         run: |
@@ -278,7 +278,7 @@ jobs:
           python-version: ${{ matrix.python }}
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: run tests for flink
         run: ./mvnw verify -pl flink/flink-scala-2.12,flink-cmd,zeppelin-interpreter-integration -Pflink-${{ matrix.flink }} -am -Pintegration -DfailIfNoTests=false -Dtest=org.apache.zeppelin.flink.*Test,FlinkIntegrationTest${{ matrix.flink }} ${MAVEN_ARGS}
@@ -326,7 +326,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
         run: |
@@ -373,7 +373,7 @@ jobs:
           python-version: ${{ matrix.python }}
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
         run: |
@@ -442,7 +442,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
         run: |

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           activate-environment: python_only
           python-version: ${{ matrix.python }}
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
           channels: conda-forge,defaults
           channel-priority: strict
@@ -192,7 +192,7 @@ jobs:
           python-version: 3.9
           channels: conda-forge,defaults
           channel-priority: strict
-          auto-activate-base: false
+          auto-activate: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
         run: |


### PR DESCRIPTION
### What is this PR for?
This PR fixes deprecation warnings in GitHub Actions workflows by replacing the deprecated `auto-activate-base` parameter with `auto-activate` in the `conda-incubator/setup-miniconda@v3` action.

The `auto-activate-base` parameter has been deprecated in favor of the more clearly named `auto-activate` parameter. This change removes deprecation warnings from GitHub Actions workflow logs while maintaining identical functionality.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Replace `auto-activate-base` with `auto-activate` in frontend.yml
* [x] - Replace `auto-activate-base` with `auto-activate` in core.yml

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6403

### How should this be tested?
* Verify that GitHub Actions workflows run without deprecation warnings
* Confirm that all conda environment setup steps work correctly
* Check that Python and R interpreters are properly activated in CI jobs

Manual testing:
1. Push the changes to a branch
2. Observe GitHub Actions workflow runs
3. Confirm no deprecation warnings appear in the setup-miniconda steps
4. Verify all jobs complete successfully

### Screenshots (if appropriate)

**Before (with deprecation warning):**
<img width="1408" height="486" alt="image" src="https://github.com/user-attachments/assets/fba1149a-074f-4fe2-a8aa-645a822ae5b4" />

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
