### PR TITLE
[ZEPPELIN-6410] Fix typo in PythonInterpreter comment: "sever" to "server"

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -122,7 +122,7 @@ public class PythonInterpreter extends Interpreter {
     }
   }
 
-  // start gateway sever and start python process
+  // start gateway server and start python process
   private void createGatewayServerAndStartScript() throws IOException {
     // start gateway server in JVM side
     int port = RemoteInterpreterUtils.findRandomAvailablePortOnAllLocalInterfaces();


### PR DESCRIPTION
### What is this PR for?
Fix a typo in `PythonInterpreter.java` where the comment reads "sever" instead of "server".

### What type of PR is it?
Improvement

### Todos
* [x] Fix typo: "sever" → "server"

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6410

### How should this be tested?
* No functional change — comment-only fix. Visual inspection is sufficient.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No