### PR TITLE
[MINOR] chore(.github): group dependabot security updates by path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Keep version updates disabled so this config only groups security updates.
   - package-ecosystem: "bundler"
     directory: "/docs"
     schedule:
@@ -29,6 +30,171 @@ updates:
     open-pull-requests-limit: 0
     groups:
       zeppelin-web-angular-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/dev"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      dev-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      root-maven-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/alluxio"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      alluxio-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/bigquery"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      bigquery-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/elasticsearch"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      elasticsearch-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/flink/flink-scala-2.12"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      flink-scala-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/livy"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      livy-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/rlang"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      rlang-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/shell"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      shell-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/spark/interpreter"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      spark-interpreter-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/spark/spark-scala-parent"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      spark-scala-parent-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/zeppelin-interpreter"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      zeppelin-interpreter-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/zeppelin-plugins/launcher/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      launcher-docker-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/zeppelin-plugins/launcher/k8s-standard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      launcher-k8s-standard-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "maven"
+    directory: "/zeppelin-plugins/notebookrepo/s3"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      notebookrepo-s3-security-updates:
         applies-to: security-updates
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      docs-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/zeppelin-web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      zeppelin-web-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/zeppelin-web-angular"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      zeppelin-web-angular-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
### What is this PR for?
Group Dependabot security updates by exact path so the current burst of one-off security PRs can be regenerated as grouped PRs instead.

This configuration intentionally keeps non-security version updates disabled with `open-pull-requests-limit: 0`, so it only affects grouped security updates and does not start regular version-update PRs for these directories.

Covered paths:
- `/docs`
- `/zeppelin-web`
- `/zeppelin-web-angular`
- `/dev`
- `/`
- `/alluxio`
- `/bigquery`
- `/elasticsearch`
- `/flink/flink-scala-2.12`
- `/livy`
- `/rlang`
- `/shell`
- `/spark/interpreter`
- `/spark/spark-scala-parent`
- `/zeppelin-interpreter`
- `/zeppelin-plugins/launcher/docker`
- `/zeppelin-plugins/launcher/k8s-standard`
- `/zeppelin-plugins/notebookrepo/s3`

First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html

### What type of PR is it?
Improvement

### Todos
* [x] Add `.github/dependabot.yml` for the targeted directories
* [x] Verify the configured directory names match the repository
* [x] Expand coverage to the remaining open Dependabot security-update paths
* [x] Clarify that the config is intentionally security-updates-only

### What is the Jira issue?
None. Minor maintenance change.

### How should this be tested?
* Confirm `.github/dependabot.yml` is valid YAML.
* Confirm each configured directory exists in the repository.
* After merge, verify Dependabot opens grouped security update PRs for the listed paths.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
