### PR TITLE
[MINOR] Drop ticket value from WebSocket debug log statements

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -279,7 +279,6 @@ public class NotebookServer implements AngularObjectRegistryListener,
       if (receivedMessage.op != OP.PING) {
         LOGGER.debug("RECEIVE: " + receivedMessage.op +
             ", RECEIVE PRINCIPAL: " + receivedMessage.principal +
-            ", RECEIVE TICKET: " + receivedMessage.ticket +
             ", RECEIVE ROLES: " + receivedMessage.roles +
             ", RECEIVE DATA: " + receivedMessage.data);
       }
@@ -289,12 +288,13 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
       TicketContainer.Entry ticketEntry = TicketContainer.instance.getTicketEntry(receivedMessage.principal);
       if (ticketEntry == null || StringUtils.isEmpty(ticketEntry.getTicket())) {
-        LOGGER.debug("{} message: invalid ticket {}", receivedMessage.op, receivedMessage.ticket);
+        LOGGER.debug("{} message: no ticket on file for principal {}",
+            receivedMessage.op, receivedMessage.principal);
         return;
       } else if (!ticketEntry.getTicket().equals(receivedMessage.ticket)) {
         /* not to pollute logs, log instead of exception */
-        LOGGER.debug("{} message: invalid ticket {} != {}", receivedMessage.op, receivedMessage.ticket,
-            ticketEntry.getTicket());
+        LOGGER.debug("{} message: ticket mismatch for principal {}",
+            receivedMessage.op, receivedMessage.principal);
         if (!receivedMessage.op.equals(OP.PING)) {
           conn.send(serializeMessage(new Message(OP.SESSION_LOGOUT).put("info",
               "Your ticket is invalid possibly due to server restart. Please login again.")));


### PR DESCRIPTION
### What is this PR for?

Removes the WebSocket auth ticket value from three `LOGGER.debug` call sites in `NotebookServer.onMessage`. The ticket is a per-session UUID and adds no debugging value beyond the principal that owns it; emitting the raw value makes it visible to anyone with access to log files or downstream log collectors.

The three call sites and the change applied to each:

- **RECEIVE block** — drops the `RECEIVE TICKET` column. The remaining `op` / `principal` / `roles` / `data` columns are sufficient to identify the message.
- **"no ticket on file" branch** — logs the principal that has no entry instead of echoing back the rejected ticket.
- **"ticket mismatch" branch** — logs the principal whose ticket did not match, rather than both raw values.

`Message.toString()` does not include the ticket field, so the surrounding `LOGGER.trace("RECEIVE MSG = " + receivedMessage)` already does not leak it.

### What type of PR is it?

Improvement

### What is the Jira issue?

N/A — minor logging hygiene change, no behavioral or API change.

### How should this be tested?

Diff is self-evident. The three changed sites stay on the existing branches; behavior (what is returned to the client, what is rejected) is unchanged. Existing `NotebookServerTest` continues to exercise these paths.

### Screenshots (if appropriate)

N/A

### Questions:

- Does the license files need to update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No