### PR TITLE
[ZEPPELIN-6419] Fix clone paragraph content loss caused by shortCircuit seq filtering

### DIFF
--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-paragraph.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-paragraph.interface.ts
@@ -77,10 +77,10 @@ export interface ParagraphConfig {
 }
 
 export interface ParagraphResults {
+  [index: number]: Record<string, unknown>;
+
   code?: string;
   msg?: ParagraphIResultsMsgItem[];
-
-  [index: number]: Record<string, unknown>;
 }
 
 export enum DatasetType {

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -40,6 +40,9 @@ export type ReceiveArgumentsType<K extends keyof MessageReceiveDataTypeMap> =
   MessageReceiveDataTypeMap[K] extends undefined ? () => void : (data: MessageReceiveDataTypeMap[K]) => void;
 
 export class Message {
+  /** Prevent unbounded growth of the short-circuit tracker */
+  private static readonly MAX_SHORT_CIRCUIT_SIZE = 100;
+
   public connectedStatus = false;
   public connectedStatus$ = new Subject<boolean>();
   private ws: WebSocketSubject<WebSocketMessage<MessageDataTypeMap>> | null = null;
@@ -61,8 +64,6 @@ export class Message {
    * unrelated requests like EDITOR_SETTING are interleaved).
    */
   private shortCircuitedParagraphMsgIds = new Set<number>();
-  /** Prevent unbounded growth of the short-circuit tracker */
-  private static readonly MAX_SHORT_CIRCUIT_SIZE = 100;
 
   constructor() {
     this.open$.subscribe(() => {

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -40,9 +40,6 @@ export type ReceiveArgumentsType<K extends keyof MessageReceiveDataTypeMap> =
   MessageReceiveDataTypeMap[K] extends undefined ? () => void : (data: MessageReceiveDataTypeMap[K]) => void;
 
 export class Message {
-  /** Prevent unbounded growth of the short-circuit tracker */
-  private static readonly MAX_SHORT_CIRCUIT_SIZE = 100;
-
   public connectedStatus = false;
   public connectedStatus$ = new Subject<boolean>();
   private ws: WebSocketSubject<WebSocketMessage<MessageDataTypeMap>> | null = null;
@@ -57,13 +54,6 @@ export class Message {
   private uniqueClientId = Math.random().toString(36).substring(2, 7);
   private lastMsgIdSeqSent = 0;
   private readonly normalCloseCode = 1000;
-  /**
-   * Track which PARAGRAPH message seq IDs were explicitly short-circuited.
-   * Only these should be filtered out — not all messages where
-   * lastMsgIdSeqSent > receivedSeq (which can happen legitimately when
-   * unrelated requests like EDITOR_SETTING are interleaved).
-   */
-  private shortCircuitedParagraphMsgIds = new Set<number>();
 
   constructor() {
     this.open$.subscribe(() => {
@@ -184,49 +174,11 @@ export class Message {
   receive<K extends keyof MessageReceiveDataTypeMap>(op: K): Observable<Record<K, MessageReceiveDataTypeMap[K]>[K]> {
     return this.received$.pipe(
       filter(message => message.op === op),
-      filter(message => {
-        if (!message.msgId) {
-          // when msgId is not specified, it is not response to client request.
-          // always process them
-          return true;
-        }
-        const uniqueClientId = message.msgId.split('-')[0];
-        const msgIdSeqReceived = parseInt(message.msgId.split('-')[1], 10);
-        const isResponseForRequestFromThisClient = uniqueClientId === this.uniqueClientId;
-
-        if (message.op === OP.PARAGRAPH) {
-          if (isResponseForRequestFromThisClient &&
-               this.shortCircuitedParagraphMsgIds.has(msgIdSeqReceived)
-          ) {
-            console.log('PARAPGRAPH is already updated by shortcircuit');
-            this.shortCircuitedParagraphMsgIds.delete(msgIdSeqReceived);
-            return false;
-          } else {
-            return true;
-          }
-        } else {
-          return true;
-        }
-      }),
       map(message => message.data)
     ) as Observable<Record<K, MessageReceiveDataTypeMap[K]>[K]>;
   }
 
   shortCircuit(message: WebSocketMessage<MessageReceiveDataTypeMap>) {
-    // Track which PARAGRAPH responses were explicitly short-circuited
-    // so the receive filter can correctly identify and skip them
-    if (message.op === OP.PARAGRAPH && message.msgId) {
-      const msgIdSeq = parseInt(message.msgId.split('-')[1], 10);
-      this.shortCircuitedParagraphMsgIds.add(msgIdSeq);
-      // Prevent unbounded growth: evict the oldest (smallest seq) entries
-      if (this.shortCircuitedParagraphMsgIds.size > Message.MAX_SHORT_CIRCUIT_SIZE) {
-        const sorted = [...this.shortCircuitedParagraphMsgIds].sort((a, b) => a - b);
-        const toDelete = sorted.slice(0, sorted.length - Message.MAX_SHORT_CIRCUIT_SIZE / 2);
-        for (const id of toDelete) {
-          this.shortCircuitedParagraphMsgIds.delete(id);
-        }
-      }
-    }
     this.received$.next(this.interceptReceived(message));
   }
 

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -52,6 +52,7 @@ export class Message {
   private wsUrl?: string;
   private ticket?: Ticket;
   private uniqueClientId = Math.random().toString(36).substring(2, 7);
+  // TODO: Clean up this variable with `msgId` in server-side. See ZEPPELIN-6419, ZEPPELIN-4985
   private lastMsgIdSeqSent = 0;
   private readonly normalCloseCode = 1000;
 

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -54,6 +54,15 @@ export class Message {
   private uniqueClientId = Math.random().toString(36).substring(2, 7);
   private lastMsgIdSeqSent = 0;
   private readonly normalCloseCode = 1000;
+  /**
+   * Track which PARAGRAPH message seq IDs were explicitly short-circuited.
+   * Only these should be filtered out — not all messages where
+   * lastMsgIdSeqSent > receivedSeq (which can happen legitimately when
+   * unrelated requests like EDITOR_SETTING are interleaved).
+   */
+  private shortCircuitedParagraphMsgIds = new Set<number>();
+  /** Prevent unbounded growth of the short-circuit tracker */
+  private static readonly MAX_SHORT_CIRCUIT_SIZE = 100;
 
   constructor() {
     this.open$.subscribe(() => {
@@ -185,8 +194,11 @@ export class Message {
         const isResponseForRequestFromThisClient = uniqueClientId === this.uniqueClientId;
 
         if (message.op === OP.PARAGRAPH) {
-          if (isResponseForRequestFromThisClient && this.lastMsgIdSeqSent > msgIdSeqReceived) {
+          if (isResponseForRequestFromThisClient &&
+               this.shortCircuitedParagraphMsgIds.has(msgIdSeqReceived)
+          ) {
             console.log('PARAPGRAPH is already updated by shortcircuit');
+            this.shortCircuitedParagraphMsgIds.delete(msgIdSeqReceived);
             return false;
           } else {
             return true;
@@ -200,6 +212,20 @@ export class Message {
   }
 
   shortCircuit(message: WebSocketMessage<MessageReceiveDataTypeMap>) {
+    // Track which PARAGRAPH responses were explicitly short-circuited
+    // so the receive filter can correctly identify and skip them
+    if (message.op === OP.PARAGRAPH && message.msgId) {
+      const msgIdSeq = parseInt(message.msgId.split('-')[1], 10);
+      this.shortCircuitedParagraphMsgIds.add(msgIdSeq);
+      // Prevent unbounded growth: evict the oldest (smallest seq) entries
+      if (this.shortCircuitedParagraphMsgIds.size > Message.MAX_SHORT_CIRCUIT_SIZE) {
+        const sorted = [...this.shortCircuitedParagraphMsgIds].sort((a, b) => a - b);
+        const toDelete = sorted.slice(0, sorted.length - Message.MAX_SHORT_CIRCUIT_SIZE / 2);
+        for (const id of toDelete) {
+          this.shortCircuitedParagraphMsgIds.delete(id);
+        }
+      }
+    }
     this.received$.next(this.interceptReceived(message));
   }
 


### PR DESCRIPTION

### What is this PR for?
**Problem**
When cloning a paragraph in zeppelin-web-angular, the cloned paragraph only contains the interpreter binding (e.g., %mysql) but not the actual editor content (e.g., select 1 a, 2 a). The old zeppelin-web handles this correctly.

**Root Cause Analysis**
The backend copyParagraph is a two-step operation:

```
1. insertParagraph() → broadcasts PARAGRAPH_ADDED (empty new paragraph, text="%mysql\n")
2. updateParagraph() → broadcasts PARAGRAPH        (full text="%mysql\nselect 1 a, 2 a")
```
Step 2's PARAGRAPH response gets silently discarded by the frontend shortCircuit mechanism in message.ts. The original filter logic compares the currently-sent message sequence number against the received response's sequence number:

```ts
// OLD logic — overly aggressive
if (this.lastMsgIdSeqSent > msgIdSeqReceived) {
  // "message is already updated by shortcircuit" → discard!
  return false;
}
```
The problem: between sending COPY_PARAGRAPH (seq=49) and receiving its PARAGRAPH response, other unrelated messages like EDITOR_SETTING (seq=50) may be sent. This makes lastMsgIdSeqSent (50) > msgIdSeqReceived (49), causing the legitimate PARAGRAPH response for the cloned paragraph to be incorrectly filtered out.

<img width="807" height="951" alt="image" src="https://github.com/user-attachments/assets/3395e3eb-352c-45f7-96ca-68d3d3f5a983" />

~~**Solution**
Replace the implicit sequence-number comparison with an explicit tracking set (shortCircuitedParagraphMsgIds). Only messages that were explicitly passed to shortCircuit() get filtered — not all messages where lastMsgIdSeqSent > receivedSeq.~~

**Updated Solution**
Dropping the PARAGRAPH msgId compare filter branch when received msg

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
