### PR TITLE
[ZEPPELIN-6426] Remove redundant eslint-disable comments in zeppelin-web-angular

### DIFF
--- a/zeppelin-web-angular/eslint.config.js
+++ b/zeppelin-web-angular/eslint.config.js
@@ -26,6 +26,13 @@ module.exports = tseslint.config(
     ignores: ['dist/**', 'target/**', '.angular/**', 'coverage/**', 'node/**', 'projects/zeppelin-react/**']
   },
   {
+    // Fail (not just warn) on eslint-disable directives that no longer suppress
+    // anything. The flat-config default is 'warn', and `ng lint` exits 0 on
+    // warnings, so stale directives would otherwise accumulate unnoticed --
+    // promoting to 'error' keeps the ZEPPELIN-6426 cleanup enforced.
+    linterOptions: { reportUnusedDisableDirectives: 'error' }
+  },
+  {
     files: ['**/*.ts'],
     // == legacy `plugin:@angular-eslint/recommended` (sets the TS parser and
     // the @angular-eslint plugin). The @typescript-eslint plugin is registered

--- a/zeppelin-web-angular/projects/zeppelin-react/eslint.config.js
+++ b/zeppelin-web-angular/projects/zeppelin-react/eslint.config.js
@@ -32,6 +32,14 @@ module.exports = tseslint.config(
     ignores: ['dist/**', 'node_modules/**', 'webpack.config.js']
   },
   {
+    // Fail (not just warn) on eslint-disable directives that no longer suppress
+    // anything. The flat-config default is 'warn', and `npm run lint:react`
+    // (plain `eslint`, no --max-warnings) exits 0 on warnings, so stale
+    // directives would otherwise accumulate unnoticed -- mirrors the root
+    // zeppelin-web-angular config (ZEPPELIN-6426).
+    linterOptions: { reportUnusedDisableDirectives: 'error' }
+  },
+  {
     files: ['src/**/*.{ts,tsx}'],
     // == legacy `extends`: eslint:recommended + @typescript-eslint/recommended
     extends: [js.configs.recommended, ...tseslint.configs.recommended],

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-common.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-common.interface.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
@@ -10,7 +10,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable jsdoc/no-types */
 /**
  * Representation of event type.
  */

--- a/zeppelin-web-angular/projects/zeppelin-visualization/src/g2-visualization-component-base.ts
+++ b/zeppelin-web-angular/projects/zeppelin-visualization/src/g2-visualization-component-base.ts
@@ -21,7 +21,6 @@ import { Visualization } from './visualization';
   template: '',
   standalone: false
 })
-// eslint-disable-next-line @angular-eslint/component-class-suffix
 export abstract class G2VisualizationComponentBase implements OnDestroy {
   abstract container: ElementRef<HTMLDivElement>;
   chart?: G2.Chart | null;

--- a/zeppelin-web-angular/projects/zeppelin-visualization/src/table-transformation.ts
+++ b/zeppelin-web-angular/projects/zeppelin-visualization/src/table-transformation.ts
@@ -14,7 +14,6 @@ import { GraphConfig } from '@zeppelin/sdk';
 import { TableData } from './table-data';
 import { Transformation } from './transformation';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class TableTransformation extends Transformation {
   constructor(config: GraphConfig) {
     super(config);

--- a/zeppelin-web-angular/src/app/app-http.interceptor.ts
+++ b/zeppelin-web-angular/src/app/app-http.interceptor.ts
@@ -28,7 +28,6 @@ export class AppHttpInterceptor implements HttpInterceptor {
   intercept(httpRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     let httpRequestUpdated = httpRequest.clone({ withCredentials: true });
     if (environment.production) {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       httpRequestUpdated = httpRequest.clone({ setHeaders: { 'X-Requested-With': 'XMLHttpRequest' } });
     }
     return next.handle(httpRequestUpdated).pipe(

--- a/zeppelin-web-angular/src/app/core/destroy-hook/destroy-hook.component.ts
+++ b/zeppelin-web-angular/src/app/core/destroy-hook/destroy-hook.component.ts
@@ -17,7 +17,6 @@ import { Subject } from 'rxjs';
   template: '',
   standalone: false
 })
-// eslint-disable-next-line @angular-eslint/component-class-suffix
 export class DestroyHookComponent implements OnDestroy {
   readonly destroy$ = new Subject<void>();
 

--- a/zeppelin-web-angular/src/app/core/message-listener/message-listener.ts
+++ b/zeppelin-web-angular/src/app/core/message-listener/message-listener.ts
@@ -19,7 +19,6 @@ import { Message, MessageReceiveDataTypeMap, ReceiveArgumentsType } from '@zeppe
   template: '',
   standalone: false
 })
-// eslint-disable-next-line @angular-eslint/component-class-suffix
 export class MessageListenersManager implements OnDestroy {
   __zeppelinMessageListeners__?: Array<() => void>;
   __zeppelinMessageListeners$__: Subscriber<unknown> | null = new Subscriber();
@@ -43,18 +42,15 @@ export function MessageListener<K extends keyof MessageReceiveDataTypeMap>(op: K
   ) {
     const oldValue = descriptor.value as ReceiveArgumentsType<K>;
 
-    // eslint-disable-next-line no-invalid-this
     const fn = function (this: MessageListenersManager) {
-      // eslint-disable-next-line no-invalid-this
       if (!this.__zeppelinMessageListeners$__) {
         throw new Error('__zeppelinMessageListeners$__ is not defined');
       }
-      // eslint-disable-next-line no-invalid-this
+
       this.__zeppelinMessageListeners$__.add(
-        // eslint-disable-next-line no-invalid-this
         this.messageService.receive(op).subscribe(data => {
           // @ts-ignore
-          // eslint-disable-next-line no-invalid-this
+
           oldValue.apply(this, [data]);
         })
       );

--- a/zeppelin-web-angular/src/app/core/message-listener/message-listener.ts
+++ b/zeppelin-web-angular/src/app/core/message-listener/message-listener.ts
@@ -50,7 +50,6 @@ export function MessageListener<K extends keyof MessageReceiveDataTypeMap>(op: K
       this.__zeppelinMessageListeners$__.add(
         this.messageService.receive(op).subscribe(data => {
           // @ts-ignore
-
           oldValue.apply(this, [data]);
         })
       );

--- a/zeppelin-web-angular/src/app/languages/scala.ts
+++ b/zeppelin-web-angular/src/app/languages/scala.ts
@@ -232,7 +232,6 @@ export const language = {
       [/[\/*]/, 'comment.doc']
     ],
 
-    // eslint-disable-next-line id-blacklist
     string: [
       [/[^\\"]+/, 'string'],
       [/@escapes/, 'string.escape'],

--- a/zeppelin-web-angular/src/app/pages/workspace/share/result/result.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/share/result/result.component.ts
@@ -596,7 +596,6 @@ export class NotebookParagraphResultComponent implements OnInit, AfterViewInit, 
     this.destroy$.complete();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private commitClassicVizConfigChange(configForMode: GraphConfig, mode: string) {
     if (this.isPending) {
       return;

--- a/zeppelin-web-angular/src/app/services/helium.service.ts
+++ b/zeppelin-web-angular/src/app/services/helium.service.ts
@@ -91,7 +91,6 @@ export class HeliumService extends BaseRest {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any)._heliumBundles = [] as HeliumBundle[];
       availableBundles.forEach(bundle => {
-        // eslint-disable-next-line no-eval
         eval(bundle);
       });
 


### PR DESCRIPTION
### What is this PR for?
zeppelin-web-angular has several eslint-disable comments that no longer suppress any violation under the current ESLint configuration (e.g. no-invalid-this, id-blacklist, no-eval, jsdoc/no-types, @typescript-eslint/naming-convention, @angular-eslint/component-class-suffix). These unused directives are misleading and add noise, so this PR removes them. No functional change.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6426

### How should this be tested?
* Run `npm run lint` in zeppelin-web-angular and confirm it still passes.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No