### PR TITLE
 [ZEPPELIN-6429] Focus paragraph editor on clone/insert in New UI

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -692,16 +692,17 @@ public class NotebookServer implements AngularObjectRegistryListener,
     inlineBroadcastParagraphs(userParagraphMap, msgId);
   }
 
-  private void inlineBroadcastNewParagraph(Note note, Paragraph para) {
+  private void inlineBroadcastNewParagraph(Note note, Paragraph para, String msgId) {
     LOGGER.info("Broadcasting paragraph on run call instead of note.");
     int paraIndex = note.getParagraphs().indexOf(para);
 
-    Message message = new Message(OP.PARAGRAPH_ADDED).put("paragraph", para).put("index", paraIndex);
+    Message message =
+        new Message(OP.PARAGRAPH_ADDED).withMsgId(msgId).put("paragraph", para).put("index", paraIndex);
     connectionManager.broadcast(note.getId(), message);
   }
 
-  private void broadcastNewParagraph(Note note, Paragraph para) {
-    inlineBroadcastNewParagraph(note, para);
+  private void broadcastNewParagraph(Note note, Paragraph para, String msgId) {
+    inlineBroadcastNewParagraph(note, para, msgId);
   }
 
   private void inlineBroadcastNoteList() {
@@ -1451,7 +1452,7 @@ public class NotebookServer implements AngularObjectRegistryListener,
           @Override
           public void onSuccess(Paragraph p, ServiceContext context) throws IOException {
             super.onSuccess(p, context);
-            broadcastNewParagraph(p.getNote(), p);
+            broadcastNewParagraph(p.getNote(), p, fromMessage.msgId);
           }
         });
 
@@ -1555,7 +1556,7 @@ public class NotebookServer implements AngularObjectRegistryListener,
                 StringUtils.isEmpty(p.getScriptText())) &&
                   isTheLastParagraph) {
                 Paragraph newPara = p.getNote().addNewParagraph(p.getAuthenticationInfo());
-                broadcastNewParagraph(p.getNote(), newPara);
+                broadcastNewParagraph(p.getNote(), newPara, fromMessage.msgId);
               }
             }
           });

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-notebook.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-notebook.interface.ts
@@ -167,6 +167,7 @@ export interface ImportNoteReceived {
 
 export interface ParagraphAdded {
   index: number;
+  msgId?: string;
   paragraph: ParagraphItem;
 }
 

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -157,6 +157,18 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
 
     definedNote.paragraphs[paragraphIndex].focus = true;
     this.cdr.markForCheck();
+
+    // Focus the editor only for a clone/insert initiated by this client (not auto-append on run or remote inserts).
+    // Defer a tick so the new paragraph's editor child exists, since `focus = true` alone misses it.
+    if (this.messageService.localAddFocusPending) {
+      this.messageService.localAddFocusPending = false;
+      const addedId = data.paragraph.id;
+      setTimeout(() => {
+        const added = this.listOfNotebookParagraphComponent?.find(e => e.paragraph.id === addedId);
+        added?.focusEditor();
+        added?.notebookParagraphCodeEditorComponent?.setRestorePosition();
+      });
+    }
   }
 
   @MessageListener(OP.SAVE_NOTE_FORMS)

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -160,8 +160,7 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
 
     // Focus the editor only for a clone/insert initiated by this client (not auto-append on run or remote inserts).
     // Defer a tick so the new paragraph's editor child exists, since `focus = true` alone misses it.
-    if (this.messageService.localAddFocusPending) {
-      this.messageService.localAddFocusPending = false;
+    if (this.messageService.consumeLocalAddFocusMsgId(data.msgId)) {
       const addedId = data.paragraph.id;
       setTimeout(() => {
         const added = this.listOfNotebookParagraphComponent?.find(e => e.paragraph.id === addedId);

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -105,13 +105,13 @@ export class NotebookParagraphCodeEditorComponent
           setTimeout(() => {
             this.autoAdjustEditorHeight();
           });
+          this.setParagraphMode(true);
           // A flush is a programmatic setValue (editor init, remote content update, patch), not a user edit.
           // Such changes must not mark the paragraph dirty.
           if (e.isFlush) {
             return;
           }
           this.textChanged.emit(this.text);
-          this.setParagraphMode(true);
         });
       })
     );

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -94,19 +94,24 @@ export class NotebookParagraphCodeEditorComponent
           this.position = e.position;
         });
       }),
-      editor.onDidChangeModelContent(() => {
+      editor.onDidChangeModelContent(e => {
         this.ngZone.run(() => {
           const model = editor.getModel();
           if (!model) {
             throw new Error('Model content changed but model not found.');
           }
           this.text = model.getValue();
-          this.textChanged.emit(this.text);
-          this.setParagraphMode(true);
           this.autoAdjustEditorHeight();
           setTimeout(() => {
             this.autoAdjustEditorHeight();
           });
+          // A flush is a programmatic setValue (editor init, remote content update, patch), not a user edit.
+          // Such changes must not mark the paragraph dirty.
+          if (e.isFlush) {
+            return;
+          }
+          this.textChanged.emit(this.text);
+          this.setParagraphMode(true);
         });
       })
     );

--- a/zeppelin-web-angular/src/app/services/message.service.ts
+++ b/zeppelin-web-angular/src/app/services/message.service.ts
@@ -94,20 +94,19 @@ export class MessageService extends Message implements OnDestroy {
   }
 
   private captureLocalAddFocusMsgId(sendMessage: () => void): void {
-    let msgId: string | undefined;
     const subscription = super
       .sent()
       .pipe(take(1))
       .subscribe(message => {
-        msgId = message.msgId;
+        if (message.msgId) {
+          this.localAddFocusMsgIds.add(message.msgId);
+        }
       });
     try {
       sendMessage();
-    } finally {
+    } catch (error) {
       subscription.unsubscribe();
-    }
-    if (msgId) {
-      this.localAddFocusMsgIds.add(msgId);
+      throw error;
     }
   }
 

--- a/zeppelin-web-angular/src/app/services/message.service.ts
+++ b/zeppelin-web-angular/src/app/services/message.service.ts
@@ -12,6 +12,7 @@
 
 import { Inject, Injectable, OnDestroy, Optional } from '@angular/core';
 import { Observable } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import { MessageInterceptor, MESSAGE_INTERCEPTOR } from '@zeppelin/interfaces';
 import {
@@ -22,6 +23,7 @@ import {
   MessageSendDataTypeMap,
   Note,
   NoteConfig,
+  OP,
   ParagraphConfig,
   ParagraphParams,
   PersonalizedMode,
@@ -38,9 +40,7 @@ import { TicketService } from './ticket.service';
   providedIn: 'root'
 })
 export class MessageService extends Message implements OnDestroy {
-  // Set by a local clone/insert so the PARAGRAPH_ADDED handler focuses the new
-  // paragraph's editor — not on auto-append or other clients' inserts.
-  localAddFocusPending = false;
+  private readonly localAddFocusMsgIds = new Set<string>();
 
   constructor(
     private baseUrlService: BaseUrlService,
@@ -51,7 +51,11 @@ export class MessageService extends Message implements OnDestroy {
   }
 
   interceptReceived(data: WebSocketMessage<MessageReceiveDataTypeMap>): WebSocketMessage<MessageReceiveDataTypeMap> {
-    return this.messageInterceptor ? this.messageInterceptor.received(data) : super.interceptReceived(data);
+    const received = this.messageInterceptor ? this.messageInterceptor.received(data) : super.interceptReceived(data);
+    if (received.op === OP.PARAGRAPH_ADDED && received.data && received.msgId) {
+      (received.data as MessageReceiveDataTypeMap[OP.PARAGRAPH_ADDED]).msgId = received.msgId;
+    }
+    return received;
   }
 
   bootstrap(): void {
@@ -80,6 +84,31 @@ export class MessageService extends Message implements OnDestroy {
 
   receive<K extends keyof MessageReceiveDataTypeMap>(op: K): Observable<Record<K, MessageReceiveDataTypeMap[K]>[K]> {
     return super.receive<K>(op);
+  }
+
+  consumeLocalAddFocusMsgId(msgId: string | undefined): boolean {
+    if (!msgId) {
+      return false;
+    }
+    return this.localAddFocusMsgIds.delete(msgId);
+  }
+
+  private captureLocalAddFocusMsgId(sendMessage: () => void): void {
+    let msgId: string | undefined;
+    const subscription = super
+      .sent()
+      .pipe(take(1))
+      .subscribe(message => {
+        msgId = message.msgId;
+      });
+    try {
+      sendMessage();
+    } finally {
+      subscription.unsubscribe();
+    }
+    if (msgId) {
+      this.localAddFocusMsgIds.add(msgId);
+    }
   }
 
   opened(): Observable<Event> {
@@ -171,8 +200,7 @@ export class MessageService extends Message implements OnDestroy {
   }
 
   insertParagraph(newIndex: number): void {
-    this.localAddFocusPending = true;
-    super.insertParagraph(newIndex);
+    this.captureLocalAddFocusMsgId(() => super.insertParagraph(newIndex));
   }
 
   copyParagraph(
@@ -182,8 +210,9 @@ export class MessageService extends Message implements OnDestroy {
     paragraphConfig: ParagraphConfig,
     paragraphParams: ParagraphParams
   ): void {
-    this.localAddFocusPending = true;
-    super.copyParagraph(newIndex, paragraphTitle, paragraphData, paragraphConfig, paragraphParams);
+    this.captureLocalAddFocusMsgId(() =>
+      super.copyParagraph(newIndex, paragraphTitle, paragraphData, paragraphConfig, paragraphParams)
+    );
   }
 
   angularObjectUpdate(

--- a/zeppelin-web-angular/src/app/services/message.service.ts
+++ b/zeppelin-web-angular/src/app/services/message.service.ts
@@ -38,6 +38,10 @@ import { TicketService } from './ticket.service';
   providedIn: 'root'
 })
 export class MessageService extends Message implements OnDestroy {
+  // Set by a local clone/insert so the PARAGRAPH_ADDED handler focuses the new
+  // paragraph's editor — not on auto-append or other clients' inserts.
+  localAddFocusPending = false;
+
   constructor(
     private baseUrlService: BaseUrlService,
     private ticketService: TicketService,
@@ -167,6 +171,7 @@ export class MessageService extends Message implements OnDestroy {
   }
 
   insertParagraph(newIndex: number): void {
+    this.localAddFocusPending = true;
     super.insertParagraph(newIndex);
   }
 
@@ -177,6 +182,7 @@ export class MessageService extends Message implements OnDestroy {
     paragraphConfig: ParagraphConfig,
     paragraphParams: ParagraphParams
   ): void {
+    this.localAddFocusPending = true;
     super.copyParagraph(newIndex, paragraphTitle, paragraphData, paragraphConfig, paragraphParams);
   }
 


### PR DESCRIPTION
### What is this PR for?
After cloning or inserting a paragraph in the New UI, the cursor stays on the wrapper element instead of the editor, so you have to click before typing. This focuses the new paragraph's editor one tick after `PARAGRAPH_ADDED`, gated to clone/insert initiated by this client so auto-append on run and other clients' inserts don't steal focus. It also skips dirty-marking on programmatic editor `setValue` (`isFlush`) so the cloned content isn't discarded. (The clone *content* loss itself is handled separately in https://github.com/apache/zeppelin/pull/5254#pullrequestreview-4415596876; this covers the *cursor* part.)

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
ZEPPELIN-6429

### How should this be tested?

### Screenshots (if appropriate)
https://github.com/user-attachments/assets/2dca9137-3eb3-49c3-bff8-da3429613025

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
