### PR TITLE
[ZEPPELIN-6424] Align web-angular README Node.js prerequisite

### DIFF
--- a/zeppelin-web-angular/README.md
+++ b/zeppelin-web-angular/README.md
@@ -23,7 +23,7 @@ Zeppelin notebooks front-end built with Angular.
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org) v16 or use [creationix/nvm](https://github.com/creationix/nvm).
+- [Node.js](https://nodejs.org) 22.21.1 or use [creationix/nvm](https://github.com/creationix/nvm).
 - NPM package manager (which is installed with Node.js by default).
 - [Angular CLI](https://angular.io/cli) version 8.3.0 or later.
 


### PR DESCRIPTION
### What is this PR for?
Updates the `zeppelin-web-angular` README Node.js prerequisite from v16 to `22.21.1`.

This matches the version pinned in `zeppelin-web-angular/.nvmrc` and `zeppelin-web-angular/pom.xml`.

### What type of PR is it?
Documentation

### Todos
* [x] Update the `zeppelin-web-angular` Node.js prerequisite

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6424

### How should this be tested?
Documentation-only change.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes