### PR TITLE
[ZEPPELIN-6430] Clean up removed R interpreter docs

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -26,7 +26,7 @@ limitations under the License.
 ## Overview
 [Livy](http://livy.io/) is an open source REST interface for interacting with Spark from anywhere. It supports executing snippets of code or programs in a Spark context that runs locally or in YARN.
 
-* Interactive Scala, Python and R shells
+* Interactive Scala and Python shells
 * Batch submissions in Scala, Java, Python
 * Multi users can share the same server (impersonation support)
 * Can be used for submitting jobs from anywhere with REST
@@ -237,7 +237,7 @@ select * from products where ${product_id=1}
 And creating dynamic format programmatically is not feasible in livy interpreter, because ZeppelinContext is not available in livy interpreter.
 
 ## Shared SparkContext
-Starting from livy 0.5 which is supported by Zeppelin 0.8.0, SparkContext is shared between scala, python, r and sql.
+Starting from livy 0.5 which is supported by Zeppelin 0.8.0, SparkContext is shared between scala, python and sql.
 That means you can query the table via `%livy.sql` when this table is registered in `%livy.spark`, `%livy.pyspark`.
 
 ## FAQ

--- a/docs/interpreter/mahout.md
+++ b/docs/interpreter/mahout.md
@@ -159,7 +159,7 @@ val Xty = drmXty.collect(::, 0)
 val beta = solve(XtX, Xty)
 ```
 
-## Leveraging Resource Pools and R for Visualization
+## Leveraging Resource Pools for Visualization
 
 Resource Pools are a powerful Zeppelin feature that lets us share information between interpreters. A fun trick is to take the output of our work in Mahout and analyze it in other languages.
 
@@ -184,39 +184,3 @@ val z = InterpreterContext.get().getResourcePool()
 ```
 
 Now we can access the resource pool in a consistent manner from the `%flinkMahout` interpreter.
-
-
-### Passing a variable from Mahout to R and Plotting
-
-In this simple example, we use Mahout (on Flink or Spark, the code is the same) to create a random matrix and then take the Sin of each element. We then randomly sample the matrix and create a tab separated string. Finally we pass that string to R where it is read as a .tsv file, and a DataFrame is created and plotted using native R plotting libraries.
-
-```scala
-val mxRnd = Matrices.symmetricUniformView(5000, 2, 1234)
-val drmRand = drmParallelize(mxRnd)
-
-
-val drmSin = drmRand.mapBlock() {case (keys, block) =>  
-  val blockB = block.like()
-  for (i <- 0 until block.nrow) {
-    blockB(i, 0) = block(i, 0)
-    blockB(i, 1) = Math.sin((block(i, 0) * 8))
-  }
-  keys -> blockB
-}
-
-z.put("sinDrm", org.apache.mahout.math.drm.drmSampleToTSV(drmSin, 0.85))
-```
-
-And then in an R paragraph...
-
-```r
-%spark.r {"imageWidth": "400px"}
-
-library("ggplot2")
-
-sinStr = z.get("flinkSinDrm")
-
-data <- read.table(text= sinStr, sep="\t", header=FALSE)
-
-plot(data,  col="red")
-```

--- a/docs/interpreter/python.md
+++ b/docs/interpreter/python.md
@@ -79,7 +79,7 @@ Zeppelin supports python language which is very popular in data analytics and ma
 
 For beginner, we would suggest you to play Python in Zeppelin docker first.
 In the Zeppelin docker image, we have already installed
-miniconda and lots of [useful python libraries](https://github.com/apache/zeppelin/blob/branch-0.10/scripts/docker/zeppelin/bin/env_python_3_with_R.yml)
+miniconda and lots of [useful python libraries](https://github.com/apache/zeppelin/blob/master/scripts/docker/zeppelin/bin/env_python_3.yml)
 including IPython's prerequisites, so `%python` would use IPython.
 
 Without any extra configuration, you can run most of tutorial notes under folder `Python Tutorial` directly.

--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Apache Spark Interpreter for Apache Zeppelin"
-description: "Apache Spark is a fast and general-purpose cluster computing system. It provides high-level APIs in Java, Scala, Python and R, and an optimized engine that supports general execution engine."
+description: "Apache Spark is a fast and general-purpose cluster computing system. It provides high-level APIs including Java, Scala and Python, and an optimized engine that supports general execution engine."
 group: interpreter
 ---
 <!--
@@ -25,7 +25,7 @@ limitations under the License.
 
 ## Overview
 [Apache Spark](http://spark.apache.org) is a fast and general-purpose cluster computing system.
-It provides high-level APIs in Java, Scala, Python and R, and an optimized engine that supports general execution graphs.
+It provides high-level APIs including Java, Scala and Python, and an optimized engine that supports general execution graphs.
 Apache Spark is supported in Zeppelin with Spark interpreter group which consists of following interpreters.
 
 <table class="table-configuration">
@@ -73,7 +73,7 @@ Apache Spark is supported in Zeppelin with Spark interpreter group which consist
   </tr>
   <tr>
     <td>Support multiple languages</td>
-    <td>Scala, SQL, Python, R are supported, besides that you can also collaborate across languages, e.g. you can write Scala UDF and use it in PySpark</td>
+    <td>Scala, SQL and Python are supported, besides that you can also collaborate across languages, e.g. you can write Scala UDF and use it in PySpark</td>
   </tr>
   <tr>
     <td>Support multiple execution modes</td>
@@ -104,7 +104,7 @@ Apache Spark is supported in Zeppelin with Spark interpreter group which consist
 
 For beginner, we would suggest you to play Spark in Zeppelin docker.
 In the Zeppelin docker image, we have already installed
-miniconda and lots of [useful python libraries](https://github.com/apache/zeppelin/blob/branch-0.10/scripts/docker/zeppelin/bin/env_python_3_with_R.yml)
+miniconda and lots of [useful python libraries](https://github.com/apache/zeppelin/blob/master/scripts/docker/zeppelin/bin/env_python_3.yml)
 including IPython prerequisites, so `%spark.pyspark` would use IPython.
 Without any extra configuration, you can run most of tutorial notes under folder `Spark Tutorial` directly.
 
@@ -365,7 +365,7 @@ You can also choose `scoped` mode. For `scoped` per note mode, Zeppelin creates 
 
 ## SparkContext, SQLContext, SparkSession, ZeppelinContext
 
-SparkContext, SparkSession and ZeppelinContext are automatically created and exposed as variable names `sc`, `spark` and `z` respectively, in Scala, Python and R environments.
+SparkContext, SparkSession and ZeppelinContext are automatically created and exposed as variable names `sc`, `spark` and `z` respectively, in Scala and Python environments.
 
 
 > Note that Scala/Python environment shares the same SparkContext, SQLContext, SparkSession and ZeppelinContext instance.

--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -165,7 +165,7 @@ Congratulations, you have successfully installed Apache Zeppelin! Here are a few
  * And then, try run Tutorial Notebooks shipped with your Zeppelin distribution.
  * And see how to change [configurations](../setup/operation/configuration.html) like port number, etc.
 
-#### Spark, Flink, SQL, Python, R and more 
+#### Spark, Flink, SQL, Python and more
  * [Spark support in Zeppelin](./spark_with_zeppelin.html), to know more about deep integration with [Apache Spark](http://spark.apache.org/). 
  * [Flink support in Zeppelin](./flink_with_zeppelin.html), to know more about deep integration with [Apache Flink](http://flink.apache.org/).
  * [SQL support in Zeppelin](./sql_with_zeppelin.html) for SQL support
@@ -174,5 +174,3 @@ Congratulations, you have successfully installed Apache Zeppelin! Here are a few
 
 #### Multi-user support ...
  * Check [Multi-user support](../setup/basics/multi_user_support.html)
-
-

--- a/docs/setup/basics/how_to_build.md
+++ b/docs/setup/basics/how_to_build.md
@@ -195,8 +195,6 @@ sudo apt-get install git
 sudo apt-get install openjdk-11-jdk
 sudo apt-get install npm
 sudo apt-get install libfontconfig
-sudo apt-get install r-base-dev
-sudo apt-get install r-cran-evaluate
 ```
 
 _Notes:_

--- a/docs/setup/deployment/virtual_machine.md
+++ b/docs/setup/deployment/virtual_machine.md
@@ -98,7 +98,6 @@ The virtual machine consists of:
  - libfontconfig to avoid phatomJs missing dependency issues
  - openjdk-7-jdk
  - Python addons: pip, matplotlib, scipy, numpy, pandas
- - [R](https://www.r-project.org/) and R Packages required to run the R Interpreter and the related R tutorial notebook, including:  Knitr, devtools, repr, rCharts, ggplot2, googleVis, mplot, htmltools, base64enc, data.table
 
 ## How to build & run Zeppelin
 

--- a/docs/usage/interpreter/overview.md
+++ b/docs/usage/interpreter/overview.md
@@ -38,7 +38,7 @@ When you click the ```+Create``` button on the interpreter page, the interpreter
 
 You can create multiple interpreters for the same engine with different interpreter setting. e.g. You can create `spark2` for Spark 2.x and create `spark1` for Spark 1.x.
 
-For each paragraph you write in Zeppelin, you need to specify its interpreter first via `%interpreter_group.interpreter_name`. e.g. `%spark.pyspark`, `%spark.r`.
+For each paragraph you write in Zeppelin, you need to specify its interpreter first via `%interpreter_group.interpreter_name`. e.g. `%spark.pyspark`, `%spark.sql`.
 
 If you specify interpreter, you can also pass local properties to it (if it needs them).  This is done by providing a set of key/value pairs, separated by comma, inside the round brackets right after the interpreter name. If key or value contain characters like `=`, or `,`, then you can either escape them with `\` character, or wrap the whole value inside the double quotes For example:
 

--- a/docs/usage/other_features/zeppelin_context.md
+++ b/docs/usage/other_features/zeppelin_context.md
@@ -35,7 +35,7 @@ environments is described below.
 
 ## Usage in Programming Language Cells
 
-In many programming-language interpreters (e.g. Apache Spark, Python, R) the zeppelin-context is available
+In many programming-language interpreters (e.g. Apache Spark and Python) the zeppelin-context is available
 as a predefined variable `z` that can be used by directly invoking its methods.
 The methods available on the `z` object are described below.
 Other interpreters based on programming languages. also provide the predefined variable `z`.
@@ -86,24 +86,6 @@ df = z.getAsDataFrame("table_name")
 {% endhighlight %}
 
   </div>
-  
-<div data-lang="R" markdown="1">
-
-{% highlight python %}
-# Get/Put object from R
-%spark.r
-
-z.put("objName", myObject)
-myObject <- z.get("objName")
-
-# df is R DataFrame
-# "table_name" must be table type. Currently only sql interpreter (%spark.sql or %jdbc) result is supported.
-df <- z.getAsDataFrame("table_name")
-
-{% endhighlight %}
-
-  </div>
-  
 </div>
 
 Currently, there're two types of data could be shared across interpreters:
@@ -303,6 +285,5 @@ At present only the SparkSQL, JDBC, and Shell interpreters support object interp
 
 Some interpreters use a subclass of `BaseZepplinContext` augmented with interpreter-specific functions.
 Such interpreter-specific functions are described within each interpreter's documentation.
-
 
 

--- a/docs/usage/zeppelin_sdk/session_api.md
+++ b/docs/usage/zeppelin_sdk/session_api.md
@@ -154,5 +154,3 @@ For more detailed usage of session api, you can check the examples in module `ze
 * [FlinkAdvancedExample2](https://github.com/apache/zeppelin/blob/master/zeppelin-client-examples/src/main/java/org/apache/zeppelin/client/examples/FlinkAdvancedExample2.java)
 * [HiveExample](https://github.com/apache/zeppelin/blob/master/zeppelin-client-examples/src/main/java/org/apache/zeppelin/client/examples/HiveExample.java)
 * [PythonExample](https://github.com/apache/zeppelin/blob/master/zeppelin-client-examples/src/main/java/org/apache/zeppelin/client/examples/PythonExample.java)
-* [RExample](https://github.com/apache/zeppelin/blob/master/zeppelin-client-examples/src/main/java/org/apache/zeppelin/client/examples/RExample.java)
-


### PR DESCRIPTION
## What changed

This cleans up documentation references left behind after the R interpreter, SparkR, and rlang code removal in ZEPPELIN-6430.

- Removed R build/runtime requirements from docs where they are no longer Zeppelin requirements.
- Removed `%spark.r` and R example blocks, and updated the generic interpreter example to use `%spark.sql`.
- Updated stale `env_python_3_with_R.yml` links to the current Python environment file.
- Removed R example links and support-list entries from interpreter, quickstart, Livy, VM, ZeppelinContext, and SDK docs.

## Why

The code removal left docs that still implied R interpreter or SparkR support. These updates avoid sending users toward removed functionality while keeping supported Python, Spark, SQL, and Mahout docs intact.

## Validation

- `git diff --check`
- `rg -n "SparkR|R interpreter|r-base|r-cran|IRkernel|R Tutorial|%spark\\.r|%r\\b|env_python_3_with_R" docs --glob "*.md"`
- Additional strict search for actual R feature remnants returned no matches; the broad search only leaves false positives such as `interpreter-base` / `interpreter-based`.
