### PR TITLE
[ZEPPELIN-6415] Fix FileSystemNotebookRepo folder move() creating parent of source instead of destination

### DIFF
--- a/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/FileSystemNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/FileSystemNotebookRepo.java
@@ -106,7 +106,7 @@ public class FileSystemNotebookRepo extends AbstractNotebookRepo {
     NotebookPathValidator.rejectTraversalSegments(folderPath);
     NotebookPathValidator.rejectTraversalSegments(newFolderPath);
     // [ZEPPELIN-4195] newFolderPath parent path maybe not exist
-    this.fs.tryMkDir(new Path(notebookDir, folderPath.substring(1)).getParent());
+    this.fs.tryMkDir(new Path(notebookDir, newFolderPath.substring(1)).getParent());
     this.fs.move(new Path(notebookDir, folderPath.substring(1)),
         new Path(notebookDir, newFolderPath.substring(1)));
   }


### PR DESCRIPTION
### What is this PR for?
The folder `move(String folderPath, String newFolderPath, AuthenticationInfo subject)` method in `FileSystemNotebookRepo` creates the parent directory of the **source** folder instead of the **destination** folder before performing the move.

Since the source folder must already exist for the move to succeed, creating its parent is redundant. Meanwhile the destination's parent directory may not exist, causing the subsequent move to fail — e.g. moving `/A/X` to `/B/X` when `/B` does not exist fails because the code creates `/A` (already present) instead of `/B`.

This PR changes the `tryMkDir` call to use `newFolderPath` (the destination) instead of `folderPath` (the source), mirroring the existing behavior already present in the note `move()` overload.

```diff
-    this.fs.tryMkDir(new Path(notebookDir, folderPath.substring(1)).getParent());
+    this.fs.tryMkDir(new Path(notebookDir, newFolderPath.substring(1)).getParent());
```

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix parent directory creation to target the destination folder

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6415

### How should this be tested?
* Existing tests in `FileSystemNotebookRepoTest` cover the folder move flow.
* Manual: move a folder into a destination whose parent directory does not yet exist (e.g. `/folder1` → `/folder2/folder3`) and verify the move succeeds and the parent (`/folder2`) is created.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No