### PR TITLE
[ZEPPELIN-6501] Reference source-of-truth for toolchain versions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,10 @@ limitations under the License.
 
 Apache Zeppelin is a web-based notebook for interactive data analytics. It provides a unified interface to multiple data processing backends (Spark, Flink, Python, JDBC, etc.) through a pluggable interpreter architecture. Each interpreter runs in its own JVM process and communicates with the server via Apache Thrift RPC.
 
-- **Language**: Java 11, Scala 2.12
+- **Language**: Java, Scala — versions in root `pom.xml` (`java.version`, `scala.binary.version`)
 - **Build**: Maven multi-module (wrapper: `./mvnw`)
-- **Frontend**: Angular 13 (Node 18) in `zeppelin-web-angular/`
-- **Version**: 0.13.0-SNAPSHOT
+- **Frontend**: Angular + TypeScript in `zeppelin-web-angular/` — versions in its `package.json`
+- **Version**: see `<version>` in root `pom.xml`
 
 ## Build & Test
 
@@ -191,7 +191,7 @@ Each interpreter is an independent Maven module inheriting from `zeppelin-interp
 
 ### Frontend
 
-- `zeppelin-web-angular/` — Angular 13, Node 18 (active frontend)
+- `zeppelin-web-angular/` — active frontend (Angular; versions in `package.json`, Node build pin in `pom.xml` `node.version`)
 - `zeppelin-web/` — Legacy AngularJS (activated with `-Pweb-classic`)
 
 ### Configuration Files
@@ -441,9 +441,9 @@ REST API classes use `@Inject` to receive these singletons.
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| JDK | 11 | Required. Not 8, not 17 |
-| Maven | 3.6.3+ | Use the wrapper `./mvnw` — no separate install needed |
-| Node.js | 18.x | Only for frontend (`zeppelin-web-angular/`) |
+| JDK | pinned in `pom.xml` (`java.version`) | Required — use exactly that major, not a newer/older JDK |
+| Maven | provided by `./mvnw` (pinned in `.mvn/wrapper/maven-wrapper.properties`) | No separate install needed |
+| Node.js | see `zeppelin-web-angular/package.json` (`engines.node`) | Only for frontend (`zeppelin-web-angular/`) |
 
 ### Initial Setup
 


### PR DESCRIPTION
### What

Resolves ZEPPELIN-6501. Rather than refreshing the hardcoded version numbers in `AGENTS.md`, this **removes the version literals and points each one to its source of truth**, so the file cannot drift again.

Changed spots: Project Overview (Language, Frontend, Version) and the Contributing → Prerequisites table (JDK, Maven, Node.js).

| Value | Now references |
|-------|----------------|
| Java / Scala | root `pom.xml` (`java.version`, `scala.binary.version`) |
| Project version | root `pom.xml` `<version>` |
| Frontend (Angular / Node) | `zeppelin-web-angular/package.json` (`engines.node`, `@angular/core`); Node build pin in `pom.xml` (`node.version`) |
| Maven | `.mvn/wrapper/maven-wrapper.properties` (the `./mvnw` wrapper pins it) |

### Why reference instead of updating the numbers

The listed values had already drifted — the frontend was documented as **Angular 13 / Node 18** but is actually **Angular 21 / Node ≥22.12**. Simply bumping them to today's values would recreate the same problem at the next upgrade: a second copy that quietly goes stale (which is exactly why this issue exists).

`AGENTS.md` is read primarily by **AI coding agents** (and new contributors). For that audience a **single source of truth is worth more than the convenience of seeing the number inline on one page** — an agent can open `package.json` / `pom.xml` in one step, whereas a stale literal actively misleads it into wrong build instructions. So the doc now keeps the *pointer* and lets the canonical file own the *value*.

Editorial guidance that is not itself a version literal is preserved (e.g. "use exactly that JDK major, not a newer/older one").

### Notes

- `CLAUDE.md` is a symlink to `AGENTS.md`, so it is covered automatically.
- Docs-only change; no build/test impact.
