### PR TITLE
[ZEPPELIN-6510] Fix broken Confluence link and remove leading blank line in Roadmap.md

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,4 +1,3 @@
-
 # Zeppelin Roadmap
 
-Please check https://cwiki.apache.org/confluence/display/ZEPPELIN/Zeppelin+Roadmap for details
+Please check https://cwiki.apache.org/confluence/display/ZEPPELIN/Roadmap for details


### PR DESCRIPTION
What is this PR for?

The Confluence wiki link in Roadmap.md was returning a 404 error because the URL referenced Zeppelin+Roadmap instead of the correct page Roadmap. This PR fixes the broken link and removes an unnecessary leading blank line at the top of the file.

What type of PR is it?

Documentation

Todos

- [x] Fix broken Confluence URL in Roadmap.md
- [x] Remove leading blank line in Roadmap.md

What is the Jira issue?

- https://issues.apache.org/jira/browse/ZEPPELIN-6510

How should this be tested?

1. Open Roadmap.md and verify the updated link redirects to the correct Confluence page.

Screenshots (if appropriate)

N/A

Questions:

- Does the license files need to update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No