### PR TITLE
[ZEPPELIN-6512] Fix typos in variable names and log messages in terminal classes

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalManager.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalManager.java
@@ -71,16 +71,16 @@ public class TerminalManager {
     if (terminalSocket2Service.containsKey(terminalSocketHashcode)) {
       terminalSocket2Service.remove(terminalSocketHashcode);
     } else {
-      LOGGER.error("Cann't find TerminalSocket: " + terminalSocketHashcode);
+      LOGGER.error("Can't find TerminalSocket: " + terminalSocketHashcode);
       LOGGER.error(terminalSocket2Service.toString());
     }
   }
 
-  public void cleanIntpContext(String nodeId) {
-    String keyPrex = nodeId + "@";
+  public void cleanIntpContext(String noteId) {
+    String keyPrefix = noteId + "@";
     for (Map.Entry<String, InterpreterContext> entity : noteParagraphId2IntpContext.entrySet()) {
       String key = entity.getKey();
-      if (key.contains(keyPrex)) {
+      if (key.contains(keyPrefix)) {
         LOGGER.info("cleanIntpContext : " + key);
         noteParagraphId2IntpContext.remove(key);
       }
@@ -109,7 +109,7 @@ public class TerminalManager {
       intpContext.getAngularObjectRegistry().add(TERMINAL_SOCKET_STATUS, TERMINAL_SOCKET_CONNECT,
           intpContext.getNoteId(), intpContext.getParagraphId());
     } else {
-      LOGGER.error("Cann't find InterpreterContext from : " + id);
+      LOGGER.error("Can't find InterpreterContext from : " + id);
       LOGGER.error(noteParagraphId2IntpContext.toString());
     }
   }
@@ -121,7 +121,7 @@ public class TerminalManager {
       intpContext.getAngularObjectRegistry().add(TERMINAL_SOCKET_STATUS, TERMINAL_SOCKET_CLOSE,
           intpContext.getNoteId(), intpContext.getParagraphId());
     } else {
-      LOGGER.error("Cann't find InterpreterContext from : " + id);
+      LOGGER.error("Can't find InterpreterContext from : " + id);
       LOGGER.error(noteParagraphId2IntpContext.toString());
     }
 
@@ -136,7 +136,7 @@ public class TerminalManager {
       intpContext.getAngularObjectRegistry().add(TERMINAL_SOCKET_STATUS, TERMINAL_SOCKET_ERROR,
           intpContext.getNoteId(), intpContext.getParagraphId());
     } else {
-      LOGGER.error("Cann't find InterpreterContext from : " + id);
+      LOGGER.error("Can't find InterpreterContext from : " + id);
       LOGGER.error(noteParagraphId2IntpContext.toString());
     }
   }

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalThread.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalThread.java
@@ -40,11 +40,11 @@ public class TerminalThread extends Thread {
   private Server jettyServer = new Server();
 
   private int port = 0;
-  private String allwedOrigin;
+  private String allowedOrigin;
 
-  public TerminalThread(int port, String allwedOrigin) {
+  public TerminalThread(int port, String allowedOrigin) {
     this.port = port;
-    this.allwedOrigin = allwedOrigin;
+    this.allowedOrigin = allowedOrigin;
   }
 
   @Override
@@ -80,7 +80,7 @@ public class TerminalThread extends Thread {
           (servletContext, container) ->
             container.addEndpoint(
                 ServerEndpointConfig.Builder.create(TerminalSocket.class, "/")
-                  .configurator(new TerminalSessionConfigurator(allwedOrigin))
+                  .configurator(new TerminalSessionConfigurator(allowedOrigin))
                   .build()));
       jettyServer.start();
       jettyServer.join();

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSocket.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSocket.java
@@ -78,7 +78,7 @@ public class TerminalSocket {
           terminalService.onTerminalResize(messageMap.get("columns"), messageMap.get("rows"));
           break;
         default:
-          LOGGER.error("Unrecodnized action: {}", message);
+          LOGGER.error("Unrecognized action: {}", message);
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
Fix typos in variable/parameter names and log messages across the terminal interpreter classes.
The changes are purely cosmetic — no logic is altered.

- `Cann't` → `Can't` in log messages (TerminalManager.java, 4 occurrences)
- `Unrecodnized` → `Unrecognized` in log message (TerminalSocket.java)
- `allwedOrigin` → `allowedOrigin` for field and parameter names (TerminalThread.java)
- `keyPrex` → `keyPrefix` for local variable name (TerminalManager.java)
- `nodeId` → `noteId` for parameter name to match actual semantics (TerminalManager.java)

### What type of PR is it?
Improvement

### Todos
* [x] Fix typos in log messages
* [x] Fix typos in variable/field/parameter names
* [x] Correct semantic naming (`nodeId` → `noteId`)

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6512

### How should this be tested?
No logic changes are made. Verify that the terminal interpreter starts and operates normally:
1. Launch Zeppelin with the Shell interpreter.
2. Open a note and run a `%sh.terminal` paragraph.
3. Confirm the terminal connects and responds without errors.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No