### PR TITLE
[ZEPPELIN-6506] Return empty list instead of null from completion() in Groovy interpreter

### DIFF
--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
@@ -117,7 +117,7 @@ public class GroovyInterpreter extends Interpreter {
   @Override
   public List<InterpreterCompletion> completion(String buf, int cursor,
                                                 InterpreterContext interpreterContext) {
-    return null;
+    return Collections.emptyList();
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
### What is this PR for?
Fix `GroovyInterpreter.completion()` to return an empty list instead of null when autocomplete is not supported. This aligns with the collection-returning method contract (Effective Java Item 54), avoids potential NullPointerExceptions in the completion call chain, and provides a safer API for programmatic use.

### What type of PR is it?
Bug Fix

### Todos
* [x] Fix `GroovyInterpreter.completion()` to return an empty list instead of null

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6506

### How should this be tested?
* Run the existing Groovy interpreter tests to ensure no regressions.

### Screenshots (if appropriate)

N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
