### PR TITLE
[ZEPPELIN-6528] Upgrade Apache Shiro from 1.13.0 to 2.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
     <commons.io.version>2.15.1</commons.io.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.cli.version>1.4</commons.cli.version>
-    <shiro.version>1.13.0</shiro.version>
-    <bouncycastle.version>1.80</bouncycastle.version>
+    <shiro.version>2.0.6</shiro.version>
+    <bouncycastle.version>1.82</bouncycastle.version>
     <maven.version>3.6.3</maven.version>
     <dropwizard.version>4.2.29</dropwizard.version>
     <micrometer.version>1.14.2</micrometer.version>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -27,7 +27,7 @@ import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.apache.shiro.realm.ldap.AbstractLdapRealm;
-import org.apache.shiro.realm.ldap.DefaultLdapContextFactory;
+import org.apache.shiro.realm.ldap.JndiLdapContextFactory;
 import org.apache.shiro.realm.ldap.LdapContextFactory;
 import org.apache.shiro.realm.ldap.LdapUtils;
 import org.apache.shiro.subject.PrincipalCollection;
@@ -105,9 +105,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
   public LdapContextFactory getLdapContextFactory() {
     if (this.ldapContextFactory == null) {
       LOGGER.debug("No LdapContextFactory specified - creating a default instance.");
-      DefaultLdapContextFactory defaultFactory = new DefaultLdapContextFactory();
-      defaultFactory.setPrincipalSuffix(this.principalSuffix);
-      defaultFactory.setSearchBase(this.searchBase);
+      JndiLdapContextFactory defaultFactory = new JndiLdapContextFactory();
       defaultFactory.setUrl(this.url);
       defaultFactory.setSystemUsername(this.systemUsername);
       defaultFactory.setSystemPassword(getSystemPassword());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
 import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.ShiroException;
+import org.apache.shiro.lang.ShiroException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.SimpleAuthenticationInfo;
@@ -66,7 +66,7 @@ import org.apache.shiro.realm.ldap.LdapUtils;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.MutablePrincipalCollection;
 import org.apache.shiro.subject.PrincipalCollection;
-import org.apache.shiro.util.StringUtils;
+import org.apache.shiro.lang.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
@@ -33,7 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.realm.jdbc.JdbcRealm;
 import org.apache.shiro.subject.Subject;
-import org.apache.shiro.util.LifecycleUtils;
+import org.apache.shiro.lang.util.LifecycleUtils;
 import org.apache.shiro.util.ThreadContext;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.realm.jwt.KnoxJwtRealm;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/shiro/AbstractShiroTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/shiro/AbstractShiroTest.java
@@ -21,7 +21,7 @@ import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.subject.support.SubjectThreadState;
-import org.apache.shiro.util.LifecycleUtils;
+import org.apache.shiro.lang.util.LifecycleUtils;
 import org.apache.shiro.util.ThreadState;
 import org.junit.jupiter.api.AfterAll;
 


### PR DESCRIPTION
### What is this PR for?

Upgrades Apache Shiro from 1.13.0 to 2.0.6, the current stable release line with active security patches. Shiro 2.x strengthens default password hashing (Argon2id instead of MD5) and provides Jakarta EE 10 support, which aligns with the jakarta.* namespace already in use by this project.

This PR also resolves a transitive BouncyCastle version conflict introduced by shiro-crypto-hash:2.0.6 pulling in bcprov-jdk18on:1.82, and fixes the two compile-breaking API changes between Shiro 1.x and 2.x.

### What type of PR is it?

Improvement

### Todos

* [x] Bump shiro.version 1.13.0 → 2.0.6 in pom.xml
* [x] Bump bouncycastle.version 1.80 → 1.82 to resolve DependencyConvergence conflict
* [x] Replace removed DefaultLdapContextFactory with JndiLdapContextFactory in ActiveDirectoryGroupRealm
* [x] Update StringUtils import to org.apache.shiro.lang.util in LdapRealm
* [x] Update LifecycleUtils import to org.apache.shiro.lang.util in AbstractShiroTest and ShiroAuthenticationServiceTest

### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-6528

### How should this be tested?

1. Build zeppelin-server module:
   ./mvnw compile -pl zeppelin-server -am -DskipTests
2. Run Shiro-related unit tests:
   ./mvnw test -pl zeppelin-server -Dtest="ShiroAuthenticationServiceTest,LdapRealmTest,LdapRealmDnInjectionTest,AnyOfRolesUserAuthorizationFilterTest"
3. Manually verify form login, LDAP authentication flows remain functional.

### Screenshots (if appropriate)

N/A

### Questions:

* Does the license files need to update? No
* Is there breaking changes for older versions? No — API-level changes are confined to internal realm and test infrastructure classes.
* Does this needs documentation? No