### PR TITLE
[ZEPPELIN-6495] Use URLSearchParams in terminal getParams helper

### DIFF
--- a/shell/src/main/resources/html/js/index.js
+++ b/shell/src/main/resources/html/js/index.js
@@ -113,12 +113,8 @@ function setupHterm() {
 }
 
 function getParams(key) {
-    var reg = new RegExp("(^|&)" + key + "=([^&]*)(&|$)");
-    var r = location.search.substr(1).match(reg);
-    if (r != null) {
-        return unescape(r[2]);
-    }
-    return null;
+    var params = new URLSearchParams(location.search);
+    return params.get(key);
 };
 
 // This will be whatever normal entry/initialization point your project uses.


### PR DESCRIPTION
### What is this PR for?
The `%sh.terminal` frontend helper `getParams(key)` in `shell/src/main/resources/html/js/index.js` parsed the query string by hand: it built a `RegExp` over `location.search`, sliced it with `substr(1)`, and decoded matches with the deprecated global `unescape(...)`. This is harder to read than the platform API and can diverge from standard URL parsing for encoded/repeated/special characters.

This PR replaces that logic with the standard `URLSearchParams` API. `URLSearchParams.get(key)` returns `null` for missing keys, so the existing behavior for the `noteId`/`paragraphId` parameters consumed by the terminal page is preserved, while relying on standard URL decoding instead of the deprecated `unescape`.

```js
function getParams(key) {
    var params = new URLSearchParams(location.search);
    return params.get(key);
}
```

The `noteId`/`paragraphId`/`t` values the server generates (see `TerminalInterpreter#createTerminalDashboard`) are plain alphanumeric IDs and a numeric timestamp, so decoded values are identical to the previous implementation for all real inputs.

### What type of PR is it?
Refactoring

### Todos
* [x] - Replace `substr(...)`/`unescape(...)` in `getParams` with `URLSearchParams`

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6495

### How should this be tested?
* The changed file is a static, vendored frontend resource (`index.js`); the `shell` module has no JavaScript test harness (no `package.json`, and the existing `TerminalInterpreterTest` covers the Java interpreter, not this script), so no automated JS test is added.
* Behavior was verified equivalent to the previous implementation:
  * encoded value (e.g. `%2F`) → decoded (`/`)
  * missing key → `null`
  * empty value (`key=`) → `""`
* Optional manual check: open a `%sh.terminal` paragraph so the terminal dashboard loads `...?noteId=<id>&paragraphId=<id>&t=<ts>`, and confirm the terminal connects and `TERMINAL_READY` carries the correct `noteId`/`paragraphId`.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No — the file already carries the Apache License 2.0 header and no new file is added.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
