### PR TITLE
[ZEPPELIN-6529] Evict note cache entries when removing a folder

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -305,9 +305,10 @@ public class NoteManager {
     Folder folder = getFolder(folderPath);
     List<NoteInfo> noteInfos = folder.getParent().removeFolder(folder.getName(), subject);
 
-    // update notesInfo
+    // update notesInfo and evict the deleted notes from the cache, mirroring removeNote
     for (NoteInfo noteInfo : noteInfos) {
       this.notesInfo.remove(noteInfo.getId());
+      this.noteCache.removeNote(noteInfo.getId());
     }
 
     return noteInfos;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/notebook/NoteManagerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/notebook/NoteManagerTest.java
@@ -175,6 +175,20 @@ class NoteManagerTest {
   }
 
   @Test
+  void testRemoveFolderEvictsNoteCache() throws IOException {
+    // add 2 notes under the same folder
+    Note note1 = createNote("/folder1/note1");
+    Note note2 = createNote("/folder1/note2");
+    noteManager.addNote(note1, AuthenticationInfo.ANONYMOUS);
+    noteManager.addNote(note2, AuthenticationInfo.ANONYMOUS);
+    assertEquals(2, noteManager.getCacheSize());
+
+    // remove folder should evict its notes from the cache as well
+    noteManager.removeFolder("/folder1", AuthenticationInfo.ANONYMOUS);
+    assertEquals(0, noteManager.getCacheSize());
+  }
+
+  @Test
   void testConcurrentOperation() throws Exception {
     int threshold = 10, noteNum = 150;
     Map<Integer, String> notes = new ConcurrentHashMap<>();


### PR DESCRIPTION
### What is this PR for?

`NoteManager.removeFolder` removed the deleted notes from `notesInfo` and the in-memory folder tree, but never evicted them from the `NoteCache`. `removeNote(String, AuthenticationInfo)` already calls `noteCache.removeNote(noteId)`, so the single-note path is clean; the folder path was not. As a result the `Note` objects for deleted notes stayed on the heap until the LRU threshold naturally evicted them, and they kept occupying cache slots that live notes could otherwise use. This is most wasteful for large folder deletions such as emptying the trash.

This PR evicts each removed note from `noteCache` in the same loop that clears `notesInfo`, mirroring the single-note removal path. There is no functional/correctness change (`processNote` already gates on `notesInfo.containsKey`), only immediate reclamation of the cache slots and heap held by deleted notes.

This was found by @ParkGyeongTae while reviewing #5288 / #5292 (ZEPPELIN-6345).

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6529

### How should this be tested?
* Added `NoteManagerTest#testRemoveFolderEvictsNoteCache`: adds two notes under `/folder1`, asserts `getCacheSize() == 2`, calls `removeFolder("/folder1", ...)`, and asserts `getCacheSize() == 0`. Fails before the change (cache size stays `2`), passes after.
* Full `NoteManagerTest` passes (6 tests), including `testLruCache` and `testNoteOperations`.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No