### PR TITLE
[ZEPPELIN-6509] Add error handling and safety guards to genthrift.sh

### DIFF
--- a/zeppelin-interpreter/src/main/thrift/genthrift.sh
+++ b/zeppelin-interpreter/src/main/thrift/genthrift.sh
@@ -17,6 +17,15 @@
 # * limitations under the License.
 # */
 
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+if [[ ! -f java_license_header.txt ]]; then
+  echo "java_license_header.txt not found in $(pwd)" >&2
+  exit 1
+fi
+
 rm -rf gen-java
 rm -rf ../java/org/apache/zeppelin/interpreter/thrift
 thrift --gen java RemoteInterpreterService.thrift


### PR DESCRIPTION
### What is this PR for?
 `genthrift.sh` (the Thrift code generation script) had no error handling. If the `thrift` compiler was missing or failed, or if the script was run from the wrong directory, 
  it could silently overwrite valid generated Java sources with empty/partial output. This PR adds basic safety guards so the script fails fast instead of corrupting the      
  source tree


### What type of PR is it?
Bug Fix


### Todos
  * [x] Add `set -euo pipefail` so any failing command aborts the script                                                                                                       
  * [x] Add `cd "$(dirname "${BASH_SOURCE[0]}")"` so the script always runs relative to its own location, regardless of the caller's working directory                         
  * [x] Check that `java_license_header.txt` exists before proceeding, and exit with a clear error message if it's missing

### What is the Jira issue?
[ZEPPELIN-6509](https://issues.apache.org/jira/browse/ZEPPELIN-6509)

### How should this be tested?
 * This is a developer-only shell script (not covered by the build/test suite), so testing is manual:                                                                         
    1. `bash -n zeppelin-interpreter/src/main/thrift/genthrift.sh` — verify syntax                                                                                             
    2. Run the script from the correct directory with `thrift` installed — confirm it still regenerates sources as before                                                      
    3. Temporarily rename/remove `java_license_header.txt` and run the script — confirm it exits with an error instead of silently producing malformed output                  
    4. Run the script from a different working directory (e.g. repo root) — confirm it still operates on the correct paths instead of deleting an unintended directory

### Screenshots (if appropriate)
  N/A (shell script change, no UI)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
