### PR TITLE
[ZEPPELIN-6496] Replace BigQuery polling stdout output with SLF4J logging

### DIFF
--- a/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
+++ b/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
@@ -174,9 +174,7 @@ public class BigQueryInterpreter extends Interpreter {
       throws IOException, InterruptedException {
     Job job = request.execute();
     while (!job.getStatus().getState().equals("DONE")) {
-      System.out.println("Job is " 
-          + job.getStatus().getState() 
-          + " waiting " + interval + " milliseconds...");
+      LOGGER.info("Job is {} waiting {} milliseconds...", job.getStatus().getState(), interval);
       Thread.sleep(interval);
       job = request.execute();
     }


### PR DESCRIPTION
### What is this PR for?
  `BigQueryInterpreter.pollJob(...)` printed job polling status directly to standard output via `System.out.println(...)`, bypassing Zeppelin's SLF4J/Log4j2 logging           
  configuration, log levels, and appenders. This made diagnostics noisy and hard to route in server/interpreter deployments. This PR replaces the direct stdout call with a    
  structured SLF4J logger call. 


### What type of PR is it?
Improvement


### Todos
  * [x] Replace `System.out.println(...)` in `pollJob(...)` with `LOGGER.info(...)`                                                                                            
  * [x] Preserve job state and wait interval information in the log message                                                                                                    
  * [x] No behavior changes to polling, sleeping, or returned job handling

### What is the Jira issue?
[ZEPPELIN-6496](https://issues.apache.org/jira/browse/ZEPPELIN-6496)

### How should this be tested?
  * `rg -n "System\.out\.println|System\.err\.println" bigquery/src/main/java/org/apache/zeppelin/bigquery` returns no results                                                 
  * `./mvnw test -pl bigquery` compiles/builds successfully                                                                                                                    
  * Manually trigger a BigQuery job poll and confirm the state/interval now appears via the configured logger instead of raw stdout  

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No   
* Is there breaking changes for older versions? No   
* Does this needs documentation? No   
