### PR TITLE
[ZEPPELIN-6494] Use HTTPS for zeppelin.apache.org links in UI

### DIFF
--- a/zeppelin-web-angular/e2e/tests/home/home-page-external-links.spec.ts
+++ b/zeppelin-web-angular/e2e/tests/home/home-page-external-links.spec.ts
@@ -51,7 +51,7 @@ test.describe('Home Page - External Links', () => {
 
       await test.step('Then it should have the correct href', async () => {
         const href = await homePage.externalLinks.mailingList.getAttribute('href');
-        expect(href).toBe('http://zeppelin.apache.org/community.html');
+        expect(href).toBe('https://zeppelin.apache.org/community.html');
       });
 
       await test.step('And it should open in a new tab', async () => {

--- a/zeppelin-web-angular/src/app/pages/workspace/home/home.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/home/home.component.html
@@ -34,7 +34,7 @@
       <a
         style="text-decoration: none"
         target="_blank"
-        href="http://zeppelin.apache.org/docs/{{ ticketService.version }}/index.html"
+        href="https://zeppelin.apache.org/docs/{{ ticketService.version }}/index.html"
       >
         Zeppelin documentation
       </a>
@@ -46,7 +46,7 @@
       Any contribution are welcome!
       <br />
       <br />
-      <a href="http://zeppelin.apache.org/community.html" target="_blank">
+      <a href="https://zeppelin.apache.org/community.html" target="_blank">
         <i nz-icon nzType="mail"></i>
         Mailing list
       </a>

--- a/zeppelin-web-angular/src/app/share/about-zeppelin/about-zeppelin.component.html
+++ b/zeppelin-web-angular/src/app/share/about-zeppelin/about-zeppelin.component.html
@@ -21,7 +21,7 @@
     <span class="about-version">{{ ticketService.version }}</span>
     <br />
     <br />
-    <a href="http://zeppelin.apache.org/" target="_blank"><span>Get involved!</span></a>
+    <a href="https://zeppelin.apache.org/" target="_blank"><span>Get involved!</span></a>
     <br />
     <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">
       <span>Licensed under the Apache License, Version 2.0</span>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -58,12 +58,12 @@ limitations under the License.
         <div class="col-md-6">
           <h4>Help</h4>
           Get started with <a style="text-decoration: none;" target="_blank" rel="noopener noreferrer"
-                              href="http://zeppelin.apache.org/docs/{{zeppelinVersion}}/index.html">Zeppelin documentation</a><br/>
+                              href="https://zeppelin.apache.org/docs/{{zeppelinVersion}}/index.html">Zeppelin documentation</a><br/>
 
           <h4>Community</h4>
           Please feel free to help us to improve Zeppelin, <br/>
           Any contribution are welcome!<br/><br/>
-          <a style="text-decoration: none;" href="http://zeppelin.apache.org/community.html"
+          <a style="text-decoration: none;" href="https://zeppelin.apache.org/community.html"
              target="_blank" rel="noopener noreferrer"><i style="font-size: 15px;" class="fa fa-users"></i> Mailing list</a><br/>
           <a style="text-decoration: none;" href="https://issues.apache.org/jira/projects/ZEPPELIN/issues/filter=allopenissues"
              target="_blank" rel="noopener noreferrer"><i style="font-size: 15px;" class="fa fa-bug"></i> Issues tracking</a><br/>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -142,7 +142,7 @@ limitations under the License.
             <span class="modal-body-about-version"> {{zeppelinVersion}} </span>
             <br/>
             <br/>
-            <a href="http://zeppelin.apache.org/" target="_blank" rel="noopener noreferrer"><span id="i18n-15">Get involved!</span></a>
+            <a href="https://zeppelin.apache.org/" target="_blank" rel="noopener noreferrer"><span id="i18n-15">Get involved!</span></a>
             <br/>
             <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer"><span id="i18n-16">Licensed under the Apache License, Version 2.0</span></a>
         </div>


### PR DESCRIPTION
### What is this PR for?

The Zeppelin UI still contained several direct `http://zeppelin.apache.org` links. The public Zeppelin site is served over HTTPS, and newer links in the codebase already use HTTPS. This PR switches the UI-facing website links from `http://` to `https://` and updates the focused E2E expectation that pinned the old scheme.

Changes (5 files, 7 links):
- `zeppelin-web-angular/src/app/pages/workspace/home/home.component.html` — documentation & community links
- `zeppelin-web-angular/src/app/share/about-zeppelin/about-zeppelin.component.html` — "Get involved!" link
- `zeppelin-web-angular/e2e/tests/home/home-page-external-links.spec.ts` — community-link expectation
- `zeppelin-web/src/app/home/home.html` — documentation & community links (classic UI)
- `zeppelin-web/src/components/navbar/navbar.html` — "Get involved!" link (classic UI)

Non-Zeppelin links (e.g. `www.apache.org/licenses/LICENSE-2.0`), version placeholders, and unrelated docs are intentionally left unchanged.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-6494](https://issues.apache.org/jira/browse/ZEPPELIN-6494)

### How should this be tested?
- Search the touched UI files and confirm no `http://zeppelin.apache.org` remains:
  ```
  rg -n "http://zeppelin.apache.org" zeppelin-web-angular/src/app/pages/workspace/home/home.component.html zeppelin-web-angular/src/app/share/about-zeppelin/about-zeppelin.component.html zeppelin-web-angular/e2e/tests/home/home-page-external-links.spec.ts zeppelin-web/src/app/home/home.html zeppelin-web/src/components/navbar/navbar.html
  ```
- `cd zeppelin-web-angular && npm run lint` — passes with no errors.

### Questions:
- Does the license apply to the code changes? Yes