### PR TITLE
[ZEPPELIN-6475] Throw clear error for missing InfluxDB token

### DIFF
--- a/influxdb/src/main/java/org/apache/zeppelin/influxdb/InfluxDBInterpreter.java
+++ b/influxdb/src/main/java/org/apache/zeppelin/influxdb/InfluxDBInterpreter.java
@@ -169,12 +169,17 @@ public class InfluxDBInterpreter extends AbstractInterpreter {
 
 
   @Override
-  public void open() {
+  public void open() throws InterpreterException {
 
     if (this.client == null) {
+      String token = getProperty(INFLUXDB_TOKEN_PROPERTY);
+      if (token == null || token.trim().isEmpty()) {
+        throw new InterpreterException("influxdb.token property is not set. Please configure the InfluxDB auth token.");
+      }
+
       InfluxDBClientOptions opt = InfluxDBClientOptions.builder()
           .url(getProperty(INFLUXDB_API_URL_PROPERTY))
-          .authenticateToken(getProperty(INFLUXDB_TOKEN_PROPERTY).toCharArray())
+          .authenticateToken(token.toCharArray())
           .logLevel(LogLevel.valueOf(
               getProperty(INFLUXDB_LOGLEVEL_PROPERTY, LogLevel.NONE.toString())))
           .org(getProperty(INFLUXDB_ORG_PROPERTY))

--- a/influxdb/src/main/java/org/apache/zeppelin/influxdb/InfluxDBInterpreter.java
+++ b/influxdb/src/main/java/org/apache/zeppelin/influxdb/InfluxDBInterpreter.java
@@ -173,7 +173,7 @@ public class InfluxDBInterpreter extends AbstractInterpreter {
 
     if (this.client == null) {
       String token = getProperty(INFLUXDB_TOKEN_PROPERTY);
-      if (token == null || token.trim().isEmpty()) {
+      if (token == null || token.isBlank()) {
         throw new InterpreterException("influxdb.token property is not set. Please configure the InfluxDB auth token.");
       }
 

--- a/influxdb/src/test/java/org/apache/zeppelin/influxdb/InfluxDBInterpeterTest.java
+++ b/influxdb/src/test/java/org/apache/zeppelin/influxdb/InfluxDBInterpeterTest.java
@@ -16,6 +16,8 @@
 package org.apache.zeppelin.influxdb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -214,6 +216,42 @@ class InfluxDBInterpeterTest {
     if (mockServer != null) {
       mockServer.shutdown();
     }
+  }
+
+  @Test
+  void testOpenWithoutToken() {
+    properties.remove("influxdb.token");
+
+    InfluxDBInterpreter interpreter = new InfluxDBInterpreter(properties);
+
+    InterpreterException exception = assertThrows(InterpreterException.class, interpreter::open);
+
+    assertTrue(exception.getMessage().contains("influxdb.token"));
+    assertTrue(exception.getMessage().contains("not set"));
+  }
+
+  @Test
+  void testOpenWithEmptyToken() {
+    properties.setProperty("influxdb.token","");
+
+    InfluxDBInterpreter interpreter = new InfluxDBInterpreter(properties);
+
+    InterpreterException exception = assertThrows(InterpreterException.class, interpreter::open);
+    
+    assertTrue(exception.getMessage().contains("influxdb.token"));
+    assertTrue(exception.getMessage().contains("not set"));
+  }
+
+  @Test
+  void testOpenWithBlankToken() {
+    properties.setProperty("influxdb.token","    ");
+
+    InfluxDBInterpreter interpreter = new InfluxDBInterpreter(properties);
+
+    InterpreterException exception = assertThrows(InterpreterException.class, interpreter::open);
+
+    assertTrue(exception.getMessage().contains("influxdb.token"));
+    assertTrue(exception.getMessage().contains("not set"));
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
`InfluxDBInterpreter.open()` read the `influxdb.token` property and immediately called `toCharArray()` on the returned value. When the token was not configured, `getProperty(...)` returned `null`, causing a `NullPointerException` without explaining that the authentication token was missing.

This PR validates the token before building the InfluxDB client. Missing, empty, and blank token values now throw an `InterpreterException` with a clear configuration message instead of a `NullPointerException`.

Unit tests were added for absent, empty, and whitespace-only token values. Other InfluxDB properties and client creation behavior are unchanged.

### What type of PR is it?
Bug Fix

### Todos
* [x] Validate missing, empty, and blank `influxdb.token` values
* [x] Throw `InterpreterException` with a clear error message
* [x] Add unit tests for each invalid token case

### What is the Jira issue?
[ZEPPELIN-6475](https://issues.apache.org/jira/browse/ZEPPELIN-6475)

### How should this be tested?
`./mvnw test -pl influxdb` passes successfully.

To run only the interpreter test:

`./mvnw test -pl influxdb -Dtest=InfluxDBInterpeterTest` passes successfully.

Missing, empty, and blank `influxdb.token` values throw `InterpreterException` instead of `NullPointerException`.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
