### PR TITLE
[ZEPPELIN-6473] Replace deprecated substr() with slice() in note-create

### DIFF
--- a/zeppelin-web-angular/src/app/services/angular-drag-drop.service.ts
+++ b/zeppelin-web-angular/src/app/services/angular-drag-drop.service.ts
@@ -74,8 +74,8 @@ export class AngularDragDropService {
               const identifierTokens = argsString ? argsString.split(',') : [];
               const args = identifierTokens.map(item => $parse(item.trim())(scope));
 
-              const constructorName =
-                _callbackStr.indexOf('.') !== -1 ? _callbackStr.substr(0, _callbackStr.indexOf('.')) : null;
+              const dotIndex = _callbackStr.indexOf('.');
+              const constructorName = dotIndex !== -1 ? _callbackStr.slice(0, dotIndex) : null;
               // @ts-ignore
               const constructorCandid = constructorName && scope[constructorName];
               const constructor =

--- a/zeppelin-web-angular/src/app/share/note-create/note-create.component.ts
+++ b/zeppelin-web-angular/src/app/share/note-create/note-create.component.ts
@@ -49,7 +49,7 @@ export class NoteCreateComponent extends MessageListenersManager implements OnIn
     this.noteListService.notes.flatList.forEach(note => {
       const noteName = note.path;
       if (noteName.match(/^\/Untitled Note [0-9]*$/)) {
-        const lastCount = +noteName.substr(15);
+        const lastCount = +noteName.slice(15);
         if (newCount <= lastCount) {
           newCount = lastCount + 1;
         }
@@ -63,13 +63,13 @@ export class NoteCreateComponent extends MessageListenersManager implements OnIn
     let newCloneName = '';
     const lastIndex = cloneNote.name.lastIndexOf(' ');
     const endsWithNumber = !!cloneNote.name.match('^.+?\\s\\d$');
-    const noteNamePrefix = endsWithNumber ? cloneNote.name.substr(0, lastIndex) : cloneNote.name;
+    const noteNamePrefix = endsWithNumber ? cloneNote.name.slice(0, lastIndex) : cloneNote.name;
     const regexp = new RegExp(`^${noteNamePrefix}.+`);
 
     this.noteListService.notes.flatList.forEach(note => {
       const noteName = note.path;
       if (noteName.match(regexp)) {
-        const lastCopyCount = parseInt(noteName.substr(lastIndex).trim(), 10);
+        const lastCopyCount = parseInt(noteName.slice(lastIndex).trim(), 10);
         newCloneName = noteNamePrefix;
         if (copyCount <= lastCopyCount) {
           copyCount = lastCopyCount + 1;


### PR DESCRIPTION
### What is this PR for?
The New UI note-create dialog generates note names using `String.prototype.substr()`, an Annex B (legacy) API the language spec recommends against and flags for eventual removal. This PR migrates the three `substr()` calls in `note-create.component.ts` to the recommended `slice()`.

The two methods are not blindly interchangeable — `substr(start, length)` takes a length, while `slice(start, end)` takes an end index — so each call site was checked individually to confirm behavior is preserved:

- `newNoteName()`: `substr(15)` → `slice(15)` — single-arg, runs to end of string (equivalent).
- `cloneNoteName()`: `substr(0, lastIndex)` → `slice(0, lastIndex)` — equivalent specifically because the start is `0`, so `length` and the end index coincide.
- `cloneNoteName()`: `substr(lastIndex)` → `slice(lastIndex)` — single-arg, runs to end of string (equivalent).

Generated names for both new notes (`Untitled Note N`) and cloned notes are unchanged from current behavior.

### What type of PR is it?
Improvement

### Todos
* [x] - Replace all three `substr()` calls with `slice()`
* [x] - Confirm no remaining `substr()` usage in the file

### What is the Jira issue?
[ZEPPELIN-6473](https://issues.apache.org/jira/browse/ZEPPELIN-6473)

### How should this be tested?
This repository's frontend has no unit-test infrastructure, so verification is via lint plus a production build:
```
cd zeppelin-web-angular
npm run lint && npm run build:angular
```
Both pass.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No