### PR TITLE
[ZEPPELIN-6542] Fix missing "Run" menu for first paragraph in Zeppelin

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/control/control.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/control/control.component.ts
@@ -98,7 +98,7 @@ export class NotebookParagraphControlComponent implements OnInit, OnChanges {
     this.listOfMenu = [
       {
         label: 'Run',
-        show: !this.first,
+        show: true,
         disabled: this.isEntireNoteRunning,
         icon: 'play-circle',
         trigger: () => this.trigger(this.runParagraph),


### PR DESCRIPTION
### What is this PR for?
The "Run" menu item for the first paragraph was not showing due to an incorrect show condition (!this.first). This change sets show: true unconditionally for the "Run" button, ensuring it is always visible for the first paragraph — which is expected behavior in Zeppelin.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6542

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
