### PR TITLE
[ZEPPELIN-6541] Pin maven-checkstyle-plugin version so it is actually applied

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,6 @@
     <plugin.avro.version>1.7.7</plugin.avro.version>
     <plugin.buildhelper.version>1.7</plugin.buildhelper.version>
     <plugin.buildnumber.version>1.4</plugin.buildnumber.version>
-    <plugin.checkstyle.version>2.17</plugin.checkstyle.version>
     <plugin.cobertura.version>2.7</plugin.cobertura.version>
     <plugin.download.version>1.6.0</plugin.download.version>
     <plugin.exec.version>1.6.0</plugin.exec.version>


### PR DESCRIPTION
### What is this PR for?
The root `pom.xml` declares a `plugin.checkstyle.version` property (`2.17`) intended to pin the `maven-checkstyle-plugin` version used across all modules, but the plugin's `<pluginManagement>` declaration never referenced it via a `<version>` tag. As a result Maven silently resolved a different, non-deterministic plugin version regardless of what the property said — confirmed locally: the property said `2.17`, but the build actually ran `checkstyle:3.4.0:check`. This PR adds the missing `<version>${plugin.checkstyle.version}</version>` tag and bumps the property to `3.6.0` (the current latest release) so the pinned version is the one that actually runs.

### What type of PR is it?
Improvement

### Todos
* [x] Add `<version>${plugin.checkstyle.version}</version>` to the `maven-checkstyle-plugin` block in `<pluginManagement>`
* [x] Bump `plugin.checkstyle.version` from `2.17` to `3.6.0`

### What is the Jira issue?
[ZEPPELIN-6541](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-6541)

### How should this be tested?
```bash
./mvnw -pl shell verify -DskipTests
```
Confirm the log shows checkstyle:3.6.0:check (not an arbitrary/older version) and the build completes with BUILD SUCCESS. No module overrides the plugin version locally, so all modules using maven-checkstyle-plugin inherit the pinned version consistently.


Screenshots (if appropriate)

N/A

Questions:

- Does the license files need to update? No.
- Is there breaking changes for older versions? No — build-time only change, no runtime behavior affected.
- Does this needs documentation? No.