### PR TITLE
[ZEPPELIN-6537] Close DockerClient in a finally block in DockerInterpreterProcess.stop()

### DIFF
--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -363,10 +363,10 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
       Thread.currentThread().interrupt();
     } catch (DockerException e) {
       LOGGER.error(e.getMessage(), e);
+    } finally {
+      // Close the docker client
+      docker.close();
     }
-
-    // Close the docker client
-    docker.close();
   }
 
   // Because docker can't create a container with the same name, it will cause the creation to fail.

--- a/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
@@ -16,11 +16,13 @@
  */
 package org.apache.zeppelin.interpreter.launcher;
 
+import com.spotify.docker.client.DockerClient;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,8 +32,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DockerInterpreterProcessTest {
@@ -141,5 +149,38 @@ class DockerInterpreterProcessTest {
     assertTrue(mapEnv.containsKey("ZEPPELIN_FORCE_STOP"));
     assertTrue(mapEnv.containsKey("SPARK_HOME"));
     assertTrue(mapEnv.containsKey("MY_ENV1"));
+  }
+
+  @Test
+  void testStopClosesDockerClientEvenWhenKillContainerThrows() throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty(
+        ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "5000");
+    HashMap<String, String> envs = new HashMap<String, String>();
+    envs.put("MY_ENV1", "V1");
+
+    DockerInterpreterProcess intp = spy(new DockerInterpreterProcess(
+        zConf,
+        "interpreter-container:1.0",
+        "shared_process",
+        "sh",
+        "shell",
+        properties,
+        envs,
+        "zeppelin.server.hostname",
+        12320,
+        5000, 10));
+
+    DockerClient mockDocker = mock(DockerClient.class);
+    Field dockerField = DockerInterpreterProcess.class.getDeclaredField("docker");
+    dockerField.setAccessible(true);
+    dockerField.set(intp, mockDocker);
+
+    doReturn(false).when(intp).isRunning();
+    doThrow(new RuntimeException("kill failed")).when(mockDocker).killContainer(anyString());
+
+    assertThrows(RuntimeException.class, intp::stop);
+
+    verify(mockDocker).close();
   }
 }


### PR DESCRIPTION
### What is this PR for?
`DockerInterpreterProcess.stop()` calls `docker.close()` after the `killContainer` / `removeContainer` try-catch, but `close()` is outside that block and the `catch` only handles `InterruptedException` and `DockerException`:

```java
try {
  docker.killContainer(containerName);
  docker.removeContainer(containerName);
} catch (InterruptedException e) { ...; Thread.currentThread().interrupt(); }
catch (DockerException e) { ... }
docker.close();   // skipped if kill/remove throws anything else
```

If `killContainer` / `removeContainer` throws an exception that is neither of those two (e.g. an unchecked `RuntimeException` from the client), the exception propagates out of `stop()` and `docker.close()` is skipped. The `DockerClient` holds an HTTP connection to the Docker daemon, so its socket and file descriptors leak. Interpreters are started and stopped repeatedly, so the leak accumulates and can exhaust file descriptors ("Too many open files") on long-running servers.

Fix: move `docker.close()` into a `finally` block so the client is always closed regardless of how `killContainer` / `removeContainer` exit.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - none

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6537

### How should this be tested?
Added `testStopClosesDockerClientEvenWhenKillContainerThrows` in `DockerInterpreterProcessTest`: it injects a mock `DockerClient`, stubs `killContainer` to throw a `RuntimeException`, calls `stop()`, and verifies the exception still propagates (`assertThrows`) while `docker.close()` is still invoked (`verify(mockDocker).close()`).

On the old code this fails with "Wanted but not invoked: dockerClient.close()"; with the fix it passes. Deterministic (mock-based), no flakiness. Full `DockerInterpreterProcessTest` passes.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No — behavior only changes on the failure path (close now always runs); the exception still propagates as before.
* Does this needs documentation? No.
