### PR TITLE
[ZEPPELIN-6467] Propagate serialization failures in Resource.serializeObject() instead of swallowing them

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/Resource.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/Resource.java
@@ -390,17 +390,12 @@ public class Resource implements JsonSerializable, Serializable {
     if (o == null || !(o instanceof Serializable)) {
       return null;
     }
-
+    
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    try {
-      ObjectOutputStream oos;
-      oos = new ObjectOutputStream(out);
+    try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
       oos.writeObject(o);
-      oos.close();
-      out.close();
-    } catch (Exception e) {
-      e.printStackTrace();
     }
+
     return ByteBuffer.wrap(out.toByteArray());
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/Resource.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/Resource.java
@@ -390,7 +390,6 @@ public class Resource implements JsonSerializable, Serializable {
     if (o == null || !(o instanceof Serializable)) {
       return null;
     }
-    
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
       oos.writeObject(o);

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/resource/ResourceTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/resource/ResourceTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 
 /**
@@ -90,4 +92,19 @@ class ResourceTest {
     Resource r = new Resource(null, new ResourceId("pool1", "name1"), "object");
     assertEquals(true, r.invokeMethod("startsWith", new Class[]{ java.lang.String.class }, new Object[]{"obj"}));
   }
+
+  @Test
+  void testSerializeObject_shouldPropagateIOException() {
+    IOException exception = assertThrows(IOException.class, () -> Resource.serializeObject(new FailingSerializable()));
+    assertEquals("Serialization failed", exception.getMessage());
+  }
+  
+  private static class FailingSerializable implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private void writeObject(ObjectOutputStream oos) throws IOException {
+      throw new IOException("Serialization failed");
+    }
+  }
+
 }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/resource/ResourceTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/resource/ResourceTest.java
@@ -98,7 +98,6 @@ class ResourceTest {
     IOException exception = assertThrows(IOException.class, () -> Resource.serializeObject(new FailingSerializable()));
     assertEquals("Serialization failed", exception.getMessage());
   }
-  
   private static class FailingSerializable implements Serializable {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
### What is this PR for?
`Resource.serializeObject(Object)` caught serialization exceptions, printed the stack trace, and still returned a `ByteBuffer` from the partially written output. When serialization failed, callers could receive truncated or empty data instead of the original `IOException`.

This PR removes the exception-swallowing catch block and uses try-with-resources for `ObjectOutputStream`. Serialization failures now propagate as the already-declared `IOException`, allowing the existing caller-side error handling to run and preventing invalid buffers from being returned.

A unit test was added with a `Serializable` object that throws `IOException` during serialization. The method signature and behavior for valid serializable objects are unchanged.


### What type of PR is it?
Bug Fix

### Todos
* [x] Remove the exception-swallowing catch block
* [x] Remove `printStackTrace()`
* [x] Propagate serialization failures as `IOException`
* [x] Use try-with-resources for `ObjectOutputStream`
* [x] Add a regression test for serialization failure

### What is the Jira issue?
[ZEPPELIN-6467](https://issues.apache.org/jira/browse/ZEPPELIN-6467)

### How should this be tested?
`./mvnw test -pl zeppelin-interpreter -Dtest=ResourceTest` passes successfully.

To verify that the shaded interpreter JAR includes the change:

`./mvnw clean package -pl zeppelin-interpreter,zeppelin-interpreter-shaded -DskipTests` passes successfully.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
