### PR TITLE
[ZEPPELIN-6471] Share a single aggregation-type constant between table and pivot

### DIFF
--- a/zeppelin-web-angular/src/app/visualizations/common/pivot-setting/pivot-setting.component.ts
+++ b/zeppelin-web-angular/src/app/visualizations/common/pivot-setting/pivot-setting.component.ts
@@ -16,6 +16,8 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } 
 import { GraphConfig } from '@zeppelin/sdk';
 import { TableData, Visualization } from '@zeppelin/visualization';
 
+import { AggregationType } from '../util/aggregation-type';
+
 @Component({
   selector: 'zeppelin-visualization-pivot-setting',
   templateUrl: './pivot-setting.component.html',
@@ -28,7 +30,7 @@ export class VisualizationPivotSettingComponent implements OnInit {
 
   config!: GraphConfig;
   columns: Array<{ name: string; index: number; aggr: string }> = [];
-  aggregates = ['sum', 'count', 'avg', 'min', 'max'];
+  aggregates: readonly AggregationType[] = ['sum', 'count', 'avg', 'min', 'max'];
 
   // eslint-disable-next-line
   drop(event: CdkDragDrop<any[]>) {

--- a/zeppelin-web-angular/src/app/visualizations/common/util/aggregation-type.ts
+++ b/zeppelin-web-angular/src/app/visualizations/common/util/aggregation-type.ts
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Single source of truth for the aggregation-type set shared by the table
+// visualization and the pivot setting UI. Only the type is shared; each
+// component keeps its own display-order array (typed readonly AggregationType[])
+// so that neither aggregation dropdown changes its visible order.
+export type AggregationType = 'count' | 'sum' | 'min' | 'max' | 'avg';

--- a/zeppelin-web-angular/src/app/visualizations/table/table-visualization.component.ts
+++ b/zeppelin-web-angular/src/app/visualizations/table/table-visualization.component.ts
@@ -18,8 +18,9 @@ import { utils, writeFile, WorkSheet } from 'xlsx';
 
 import { TableData, Visualization, VISUALIZATION } from '@zeppelin/visualization';
 
+import { AggregationType } from '../common/util/aggregation-type';
+
 type ColType = 'string' | 'date' | 'number';
-type AggregationType = 'count' | 'sum' | 'min' | 'max' | 'avg';
 
 class FilterOption {
   sort: 'desc' | 'asc' | '' = '';
@@ -59,7 +60,7 @@ export class TableVisualizationComponent implements OnInit {
   columns: string[] = [];
   colOptions = new Map<string, FilterOption>();
   types: ColType[] = ['string', 'number', 'date'];
-  aggregations: AggregationType[] = ['count', 'sum', 'min', 'max', 'avg'];
+  aggregations: readonly AggregationType[] = ['count', 'sum', 'min', 'max', 'avg'];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   @ViewChild(NzTableComponent, { static: false }) nzTable!: NzTableComponent<any>;
 


### PR DESCRIPTION
### What is this PR for?

The Angular frontend hardcoded the same aggregation-type set (count, sum, min, max, avg) in two independent places — the table visualization and the pivot setting UI — with no single source of truth. The table component declared a local, unexported `AggregationType` union plus a value array; the pivot component had only an untyped `string[]` with the same values in a different order. Duplication meant the two could silently drift, and type safety was inconsistent.

This PR extracts a single shared **type** and has both components consume it, while each component keeps its own display-order array.

### What changes were proposed in this PR?

- Add `common/util/aggregation-type.ts` exporting `AggregationType` as the single shared type for the aggregation-type set.
- `table-visualization.component.ts`: remove the local, unexported `AggregationType` type and import the shared one. `aggregations` keeps its existing order and is now typed `readonly AggregationType[]`.
- `pivot-setting.component.ts`: replace the untyped `string[]` with `readonly AggregationType[]` from the shared type, keeping its existing order.

Both usages are read-only iteration/display (`@for`), so `readonly` is safe. The table's `switch (opt.aggregation)` stays exhaustive against the shared type.

#### Why share the type only (not a shared value array)

Both arrays drive an aggregation dropdown in the UI:
- pivot: `pivot-setting.component.html` `@for (aggregate of aggregates; ...)`
- table: `table-visualization.component.html:112` `@for (aggregation of aggregations; ...)` rendered via `{{ aggregation | titlecase }}`

The two arrays use different orders. Collapsing them onto one canonical array would reorder the table column's Aggregation dropdown (Count, Sum, Min, Max, Avg → Sum, Count, Avg, Min, Max) — cosmetic, but a visible change the issue did not intend. Sharing only the type removes the duplicated/untyped definition and guarantees the two sets stay in sync, while leaving **both dropdowns exactly as they are today** — no user-visible change.

### How should this be tested?

There is no frontend unit-test infrastructure in this project, so regression is confirmed via lint + build:

```
cd zeppelin-web-angular && npm run lint && npm run build:angular
```

Both pass (0 lint errors, successful production build). Manually verified that both aggregation dropdowns are unchanged:
- pivot setting dropdown still shows `Sum, Count, Avg, Min, Max`
- table column Aggregation dropdown still shows `Count, Sum, Min, Max, Avg`

### Questions

- Does the license files need to update? No
- Is there breaking change for older versions? No
- Does this needs documentation? No
