### PR TITLE
[ZEPPELIN-6435] Remove frontend build dependency from IndexHtmlServletTest

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/server/IndexHtmlServletTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/server/IndexHtmlServletTest.java
@@ -25,11 +25,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
-
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletContext;
@@ -43,8 +44,9 @@ class IndexHtmlServletTest {
     private final static String TEST_HEAD_ADDON = "<!-- bar -->";
 
     private final static String FILE_PATH_INDEX_HTML_ZEPPELIN_WEB = "../zeppelin-web/dist/index.html";
-    private final static String FILE_PATH_INDEX_HTML_ZEPPELIN_WEB_ANGULAR = "../zeppelin-web-angular/dist/zeppelin/index.html";
-
+    
+    @TempDir
+    Path tempDir;
 
     @Test
     void testZeppelinWebHtmlAddon() throws IOException, ServletException {
@@ -80,16 +82,24 @@ class IndexHtmlServletTest {
     }
 
     @Test
-    @Disabled("ignored due to zeppelin-web-angular not build for core tests")
     void testZeppelinWebAngularHtmlAddon() throws IOException, ServletException {
       ZeppelinConfiguration zConf = mock(ZeppelinConfiguration.class);
       when(zConf.getHtmlBodyAddon()).thenReturn(TEST_BODY_ADDON);
       when(zConf.getHtmlHeadAddon()).thenReturn(TEST_HEAD_ADDON);
 
+      Path indexHtml = tempDir.resolve("index.html");
+      Files.writeString(
+        indexHtml,
+        "<!doctype html>\n"
+          + "<html>\n"
+          + "  <head><title>Zeppelin</title></head>\n"
+          + "  <body><zeppelin-root></zeppelin-root></body>\n"
+          + "</html>\n");
+
       ServletConfig sc = mock(ServletConfig.class);
       ServletContext ctx = mock(ServletContext.class);
       when(ctx.getResource("/index.html"))
-        .thenReturn(new URL("file:" + FILE_PATH_INDEX_HTML_ZEPPELIN_WEB_ANGULAR));
+        .thenReturn(indexHtml.toUri().toURL());
       when(sc.getServletContext()).thenReturn(ctx);
 
       IndexHtmlServlet servlet = new IndexHtmlServlet(zConf, null);
@@ -106,8 +116,7 @@ class IndexHtmlServletTest {
       // Get Content
       String content = new String(out.toString());
 
-      assertThat(content, containsString(TEST_BODY_ADDON));
-      assertThat(content, containsString(TEST_HEAD_ADDON));
-
+      assertThat(content, containsString(TEST_HEAD_ADDON + "</head>"));
+      assertThat(content, containsString(TEST_BODY_ADDON + "</body>"));
     }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/server/IndexHtmlServletTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/server/IndexHtmlServletTest.java
@@ -44,7 +44,6 @@ class IndexHtmlServletTest {
     private final static String TEST_HEAD_ADDON = "<!-- bar -->";
 
     private final static String FILE_PATH_INDEX_HTML_ZEPPELIN_WEB = "../zeppelin-web/dist/index.html";
-    
     @TempDir
     Path tempDir;
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/server/IndexHtmlServletTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/server/IndexHtmlServletTest.java
@@ -17,6 +17,7 @@
 package org.apache.zeppelin.server;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +25,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -43,7 +43,6 @@ class IndexHtmlServletTest {
     private final static String TEST_BODY_ADDON = "<!-- foo -->";
     private final static String TEST_HEAD_ADDON = "<!-- bar -->";
 
-    private final static String FILE_PATH_INDEX_HTML_ZEPPELIN_WEB = "../zeppelin-web/dist/index.html";
     @TempDir
     Path tempDir;
 
@@ -53,10 +52,18 @@ class IndexHtmlServletTest {
       when(zConf.getHtmlBodyAddon()).thenReturn(TEST_BODY_ADDON);
       when(zConf.getHtmlHeadAddon()).thenReturn(TEST_HEAD_ADDON);
 
+      Path indexHtml = tempDir.resolve("index.html");
+      Files.writeString(
+        indexHtml,
+        "<!doctype html>\n"
+          + "<html>\n"
+          + "  <head><title>Zeppelin</title>\n"
+          + "  <body>\n");
+
       ServletConfig sc = mock(ServletConfig.class);
       ServletContext ctx = mock(ServletContext.class);
       when(ctx.getResource("/index.html"))
-        .thenReturn(new URL("file:" + FILE_PATH_INDEX_HTML_ZEPPELIN_WEB));
+        .thenReturn(indexHtml.toUri().toURL());
       when(sc.getServletContext()).thenReturn(ctx);
 
       IndexHtmlServlet servlet = new IndexHtmlServlet(zConf, null);
@@ -75,8 +82,8 @@ class IndexHtmlServletTest {
       // Get Content
       String content = new String(out.toString());
 
-      assertThat(content, containsString(TEST_BODY_ADDON));
-      assertThat(content, containsString(TEST_HEAD_ADDON));
+      assertThat(content, containsString(TEST_HEAD_ADDON + "<body>"));
+      assertThat(content, endsWith(TEST_BODY_ADDON));
 
     }
 


### PR DESCRIPTION
### What is this PR for?
`IndexHtmlServletTest` included a disabled Angular HTML addon test because it depended on the generated file at `zeppelin-web-angular/dist/zeppelin/index.html`. That artifact is not built during normal `zeppelin-server` tests, so the test could not run independently.

This PR replaces the frontend build dependency with a temporary, test-owned `index.html` file and re-enables `testZeppelinWebAngularHtmlAddon`.

The `zeppelin-web` index and the Angular-style index exercise different branches in `IndexHtmlServlet`. The `zeppelin-web` index does not contain explicit `</head>` and `</body>` closing tags, so the servlet falls back to inserting the head addon before `<body>` and the body addon before `</html>`. The Angular-style index contains both closing tags, so the re-enabled test verifies that the configured head and body addons are inserted immediately before `</head>` and `</body>`.

### What type of PR is it?
Improvement

### Todos
- [x] Remove the dependency on `zeppelin-web-angular/dist/zeppelin/index.html`
- [x] Create a temporary, test-owned Angular-style `index.html`
- [x] Re-enable `testZeppelinWebAngularHtmlAddon`
- [x] Verify addon insertion before `</head>` and `</body>`

### What is the Jira issue?
[[ZEPPELIN-6435]](https://issues.apache.org/jira/browse/ZEPPELIN-6435)

### How should this be tested?
`./mvnw test -pl zeppelin-server -Dtest=IndexHtmlServletTest` passes successfully.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
