### PR TITLE
[ZEPPELIN-6534] Escape note name before building clone-name RegExp

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -272,7 +272,7 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
   }
 
   onParagraphSearch(term: string) {
-    this.listOfNotebookParagraphComponent.forEach(comp => comp.highlightMatches(term || ''));
+    this.listOfNotebookParagraphComponent?.forEach(comp => comp.highlightMatches(term || ''));
   }
 
   saveParagraph(id: string) {

--- a/zeppelin-web-angular/src/app/share/note-create/note-create.component.ts
+++ b/zeppelin-web-angular/src/app/share/note-create/note-create.component.ts
@@ -64,7 +64,8 @@ export class NoteCreateComponent extends MessageListenersManager implements OnIn
     const lastIndex = cloneNote.name.lastIndexOf(' ');
     const endsWithNumber = !!cloneNote.name.match('^.+?\\s\\d$');
     const noteNamePrefix = endsWithNumber ? cloneNote.name.slice(0, lastIndex) : cloneNote.name;
-    const regexp = new RegExp(`^${noteNamePrefix}.+`);
+    const escapedNoteNamePrefix = noteNamePrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regexp = new RegExp(`^${escapedNoteNamePrefix}.+`);
 
     this.noteListService.notes.flatList.forEach(note => {
       const noteName = note.path;


### PR DESCRIPTION
### What is this PR for?

Cloning a note whose name contains a regular-expression metacharacter (for example `[`, `(`, or a trailing backslash) threw an uncaught `SyntaxError` when the clone dialog opened, so the suggested clone name was never generated and the dialog was broken for that note. `cloneNoteName()` interpolated the note name directly into a `RegExp` source without escaping it. This PR escapes the note name before building the `RegExp`, so any note name is matched literally.

While verifying the fix in the running UI, a second, pre-existing defect surfaced in the same note view: opening **any** note logged an uncaught `TypeError: Cannot read properties of undefined (reading 'forEach')`. In `ngOnInit`, the `queryParamMap` subscription runs synchronously via `startWith()` and calls `onParagraphSearch()` before the `@ViewChildren` `QueryList` (`listOfNotebookParagraphComponent`) is populated (it is only available after `ngAfterViewInit`). This PR guards that call with optional chaining, consistent with the existing null handling elsewhere in the same component. It is included here as a small drive-by fix, in its own commit so it can be split out if preferred.

### What type of PR is it?

Bug Fix

### Todos

* [x] Escape note name before building the clone-name `RegExp`
* [x] Guard `onParagraphSearch()` against an uninitialized `@ViewChildren` `QueryList`

### What is the Jira issue?

[ZEPPELIN-6534](https://issues.apache.org/jira/browse/ZEPPELIN-6534)

### How should this be tested?

* `cd zeppelin-web-angular && npm run lint`
* Create a note named `report[2024` (or `foo(bar`) and click **Clone**: before the fix the dialog throws `SyntaxError` and no name is suggested; after the fix it suggests `report[2024 1` and clones normally. Clone-name numbering for ordinary names is unchanged (escaping is a no-op when there are no metacharacters).
* Open any note with the browser devtools console open: before the fix a `forEach` `TypeError` is logged on load; after the fix the console is clean.

### Questions:

* Does the license files need to be updated? No
* Are there breaking changes for older versions? No
* Does this need documentation? No
