### PR TITLE
[ZEPPELIN-6535] Match table column filter terms literally instead of as regex

### DIFF
--- a/zeppelin-web-angular/src/app/visualizations/table/table-visualization.component.ts
+++ b/zeppelin-web-angular/src/app/visualizations/table/table-visualization.component.ts
@@ -208,8 +208,9 @@ export class TableVisualizationComponent implements OnInit {
         sortKeys.push((row: any) => typeCoercion(row[key], value.type));
         sortTypes.push(value.sort);
       }
+      const term = value.term.trim();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      terms.push((row: any) => String(row[key]).search(value.term) !== -1);
+      terms.push((row: any) => String(row[key]).includes(term));
     });
     this.rows = filter(this.tableData.rows, row => terms.every(term => term(row)));
     this.rows = orderBy(this.rows, sortKeys, sortTypes);


### PR DESCRIPTION
### What is this PR for?
Typing a regular-expression metacharacter (for example `[`, `(`, `*`) into a Table visualization's per-column      
search box threw an uncaught SyntaxError and silently broke the column filter, because the term was compiled as a  
regular expression. In `filterRows()`, each column's filter predicate called `String(row[key]).search(value.term)`,
and `String.prototype.search()` coerces its argument to a RegExp, so the raw user-typed term became a pattern;     
benign metacharacters such as `.` or `*` also silently changed the match semantics instead of throwing an error.   
                                                                                                                   
This PR replaces `.search()` with `String.prototype.includes()`, so the term is always matched as a literal        
substring instead of being compiled as a regex. The term is also trimmed before matching, so leading/trailing      
whitespace typed into the search box doesn't affect the result.     


### What type of PR is it?
Bug Fix

### Todos
  - [x] Match table column filter terms literally instead of compiling them as a RegExp                              

### What is the Jira issue?
[ZEPPELIN-6535](https://issues.apache.org/jira/browse/ZEPPELIN-6535)

### How should this be tested?
  - `cd zeppelin-web-angular && npm run lint`                                                                        
  - Produce a Table result (e.g. run `print("%table Name\tValue\nAlice\t10\nBob\t20")` in a `%python` paragraph),    
  open a column's filter dropdown (▼ icon) and type `[` into the search box: before the fix, filtering breaks with an
  `Invalid regular expression` error in the console and stops updating; after the fix it filters literally with no   
  error.                                                                                                             
  - Type an ordinary substring (e.g. `Ali`): matching behavior is unchanged from before the fix.        

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
