### PR TITLE
[ZEPPELIN-6498] Fix broken interpreter binding mode link in interpreter overview docs

### DIFF
--- a/docs/usage/interpreter/overview.md
+++ b/docs/usage/interpreter/overview.md
@@ -123,7 +123,7 @@ This approach works, but is not convenient. Inline generic configuration can pro
 
 `ConfInterpreter` is a generic interpreter that can be used by any interpreter. You can use it just like defining a java property file.
 It can be used to make custom settings for any interpreter. However, `ConfInterpreter` needs to run before that interpreter process is launched. When that interpreter process is launched is determined by the interpreter binding mode setting.
-So users need to understand the [interpreter binding mode setting](./interpreter_bindings_mode.html) of Zeppelin and be aware of when the interpreter process is launched. E.g., if we set the Spark interpreter setting as isolated per note, then under this setting, each note will launch one interpreter process. 
+So users need to understand the [interpreter binding mode setting](./interpreter_binding_mode.html) of Zeppelin and be aware of when the interpreter process is launched. E.g., if we set the Spark interpreter setting as isolated per note, then under this setting, each note will launch one interpreter process. 
 In this scenario, users need to put `ConfInterpreter` as the first paragraph as in the below example. Otherwise, the customized setting cannot be applied (actually it would report `ERROR`).
 
 <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/conf_interpreter.png" width="600px">

--- a/docs/usage/interpreter/overview.md
+++ b/docs/usage/interpreter/overview.md
@@ -123,7 +123,7 @@ This approach works, but is not convenient. Inline generic configuration can pro
 
 `ConfInterpreter` is a generic interpreter that can be used by any interpreter. You can use it just like defining a java property file.
 It can be used to make custom settings for any interpreter. However, `ConfInterpreter` needs to run before that interpreter process is launched. When that interpreter process is launched is determined by the interpreter binding mode setting.
-So users need to understand the [interpreter binding mode setting](../usage/interpreter/interpreter_bindings_mode.html) of Zeppelin and be aware of when the interpreter process is launched. E.g., if we set the Spark interpreter setting as isolated per note, then under this setting, each note will launch one interpreter process. 
+So users need to understand the [interpreter binding mode setting](./interpreter_bindings_mode.html) of Zeppelin and be aware of when the interpreter process is launched. E.g., if we set the Spark interpreter setting as isolated per note, then under this setting, each note will launch one interpreter process. 
 In this scenario, users need to put `ConfInterpreter` as the first paragraph as in the below example. Otherwise, the customized setting cannot be applied (actually it would report `ERROR`).
 
 <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/conf_interpreter.png" width="600px">


### PR DESCRIPTION
### What is this PR for?
This PR fixes a broken relative link in the ConfInterpreter section of the interpreter overview documentation.

The page previously linked to `../usage/interpreter/interpreter_bindings_mode.html`, but the actual interpreter binding mode document is `interpreter_binding_mode.md` and is published as `interpreter_binding_mode.html`. This updates the link to the correct relative target

### What type of PR is it?
Documentation

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6498

### How should this be tested?
* Search the file for the broken target:
 ```
rg -n "interpreter_bindings_mode|\.\./usage/interpreter/interpreter_binding" docs/usage/interpreter/overview.md
```

* Confirm `docs/usage/interpreter/interpreter_binding_mode.md` exists.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
