### PR TITLE
[ZEPPELIN-6532] Complete destroy$ in paragraph ngOnDestroy to stop leaking subscriptions

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
@@ -775,5 +775,7 @@ export class NotebookParagraphComponent
 
   ngOnDestroy(): void {
     super.ngOnDestroy();
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
### What is this PR for?
Destroying a notebook paragraph did not tear down its own long-lived subscriptions or the shortcut key listeners it registered. ngOnDestroy() only called super.ngOnDestroy(), which (via MessageListenersManager) unsubscribes
  the @MessageListener subscriptions but never touches destroy$. Subscriptions gated on takeUntil(this.destroy$) - keyBinderService.keyEvent(), angularContextManager.runParagraphAction(), and .contextChanged() - are on singleton services, so a destroyed paragraph instance stayed reachable and kept receiving callbacks after being removed from the DOM. The shortcut keydown listeners registered by KeyBinder via shortcutService.bindShortcut() were also never released.

This PR emits and completes destroy$ in ngOnDestroy, after super.ngOnDestroy(), matching the pattern already used in result.component.ts and dynamic-forms.component.ts.


### What type of PR is it?
Bug Fix

### Todos
- [x] Emit and complete destroy$ in paragraph ngOnDestroy

### What is the Jira issue?
[ZEPPELIN-6532](https://issues.apache.org/jira/browse/ZEPPELIN-6532)


### How should this be tested?
* `cd zeppelin-web-angular && npm run lint`
* At runtime, subscribe to a paragraph component's destroy$, then remove it (or navigate away): before the fix destroy$ never completes even though the paragraph is removed from the DOM; after the fix it completes on destroy, and the keyEvent/runParagraphAction/contextChanged subscriptions stop firing along with the shortcut keydown listeners.                                         

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
