### PR TITLE
[ZEPPELIN-6441] Replace outdated type assertions with satisfies

### DIFF
--- a/zeppelin-web-angular/src/app/app.module.ts
+++ b/zeppelin-web-angular/src/app/app.module.ts
@@ -60,8 +60,7 @@ registerLocaleData(en);
       useValue: {
         defaultEditorOption: {
           scrollBeyondLastLine: false
-          // TODO: Change 'as' to 'satisfies' when typescript version is over 4.9 to detect unsupported editor options at compile time.
-        } as JoinedEditorOptions,
+        } satisfies JoinedEditorOptions,
         onLoad: loadMonaco
       }
     },

--- a/zeppelin-web-angular/src/app/key-binding/notebook-paragraph-keyboard-event-handler.ts
+++ b/zeppelin-web-angular/src/app/key-binding/notebook-paragraph-keyboard-event-handler.ts
@@ -69,12 +69,7 @@ export const ParagraphActionToHandlerName = {
   [ParagraphActions.PasteLine]: 'handlePasteLine',
   [ParagraphActions.SearchInsideCode]: 'handleSearchInsideCode',
   [ParagraphActions.FindInCode]: 'handleFindInCode'
-} as const;
-// TODO: Replace `as const` with
-//       `satisfies Record<ParagraphActions, keyof NotebookParagraphKeyboardEventHandler>`
-//       when typescript version is over 4.9.
-//       This allows checking both keys and values at the type level,
-//       while preserving the binding between them.
+} as const satisfies Record<ParagraphActions, keyof NotebookParagraphKeyboardEventHandler>;
 
 // Referenced only via `typeof` below to derive a type; the runtime binding is intentionally unused.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -85,10 +80,7 @@ const MonacoHandledParagraphActions = [
   ParagraphActions.CutLine,
   ParagraphActions.PasteLine,
   ParagraphActions.SearchInsideCode
-] as const;
-// TODO: Replace `as const` with `satisfies ParagraphActions[]` when typescript version is over 4.9.
-//       This ensures that the array contains only valid ParagraphActions,
-//       while preserving the literal value of the each element.
+] as const satisfies ParagraphActions[];
 
 type MonacoHandledParagraphAction = (typeof MonacoHandledParagraphActions)[number];
 

--- a/zeppelin-web-angular/src/app/pages/workspace/interpreter/create-repository-modal/create-repository-modal.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/interpreter/create-repository-modal/create-repository-modal.component.ts
@@ -73,7 +73,6 @@ export class InterpreterCreateRepositoryModalComponent extends DestroyHookCompon
       ],
       proxyLogin: '',
       proxyPassword: ''
-      // TODO: Change 'as' to 'satisfies' when typescript version is over 4.9 to detect unsupported editor options at compile time.
-    } as Record<keyof CreateInterpreterRepositoryForm, unknown>);
+    } satisfies Record<keyof CreateInterpreterRepositoryForm, unknown>);
   }
 }


### PR DESCRIPTION
### What is this PR for?
The Angular UI now uses TypeScript ~5.9.3, so the pre-4.9 workaround TODOs that asked to replace broad type assertions with `satisfies` are obsolete. This replaces those outdated assertions with `satisfies`, which improves compile-time checking without changing runtime behavior.

- `app.module.ts`: `as JoinedEditorOptions` → `satisfies JoinedEditorOptions`, so unsupported editor options are caught at compile time.
- `create-repository-modal.component.ts`: `as Record<...>` → `satisfies Record<...>`, so every form control key is validated against `CreateInterpreterRepositoryForm`.
- `notebook-paragraph-keyboard-event-handler.ts`: `as const` → `as const satisfies ...` for both the action→handler map and the Monaco-handled action list. `as const` is intentionally kept so the downstream `typeof`-based literal indexing still narrows correctly, while `satisfies` now validates keys/values (e.g. invalid handler names are rejected).

All three changes are compile-time-only annotations; runtime behavior is unchanged.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-6441](https://issues.apache.org/jira/browse/ZEPPELIN-6441)

### How should this be tested?
- `cd zeppelin-web-angular && npm run lint` passes (0 errors).
- Verified the `satisfies` checks are active: injecting an unsupported editor option is caught as TS2353, and an invalid handler name is caught as TS2418.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this need documentation? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)