### PR TITLE
[ZEPPELIN-6464] Throw IllegalArgumentException for an unsupported Scala version in SparkInterpreterLauncher

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -285,7 +285,7 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
       } else if (scalaVersion.startsWith("2.13")) {
         return "2.13";
       } else {
-        throw new Exception("Unsupported scala version: " + scalaVersion);
+        throw new IllegalArgumentException("Unsupported scala version: " + scalaVersion);
       }
     } else {
       return detectSparkScalaVersionByReplClass(sparkHome);


### PR DESCRIPTION
### What is this PR for?
This PR updates `SparkInterpreterLauncher` to throw `IllegalArgumentException` when the Scala version parsed from `spark-submit --version` is outside the supported range.

Unsupported Scala versions are invalid input values for this validation path, so `IllegalArgumentException` better describes the failure than a generic `Exception`.

The exception message is intentionally unchanged, and the `detectSparkScalaVersion(...)` method signature still declares `throws Exception` because the method can still raise checked exceptions from process execution, stream reading, and fallback Scala version detection.

This is behavior-preserving for callers: the existing caller catches `Exception` and wraps it in an `IOException`, so the surfaced behavior and public API remain unchanged.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6464

### How should this be tested?
* Build and run the module tests:
```  
./mvnw test -pl zeppelin-server --am
```

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
