### PR TITLE
[ZEPPELIN-6479] Harden Hive version parsing against missing-dot and qualifier-suffix versions

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
@@ -219,11 +219,25 @@ public class HiveUtils {
   }
 
   // Hive progress bar is supported from hive 2.3 (HIVE-16045)
-  private static boolean isProgressBarSupported(String hiveVersion) {
-    String[] tokens = hiveVersion.split("\\.");
-    int majorVersion = Integer.parseInt(tokens[0]);
-    int minorVersion = Integer.parseInt(tokens[1]);
-    return majorVersion > 2 || ((majorVersion == 2) && minorVersion >= 3);
+  static boolean isProgressBarSupported(String hiveVersion) {
+    if (StringUtils.isBlank(hiveVersion)) {
+      return false;                                       // null / blank -> unsupported
+    }
+    // Drop any qualifier after the numeric version: "3-cdh" -> "3", "2.3-dev" -> "2.3"
+    String[] tokens = hiveVersion.replaceAll("[^0-9.].*$", "").split("\\.");
+    try {
+      int majorVersion = Integer.parseInt(tokens[0]);
+      if (majorVersion >= 3) {
+        return true;                                      // 3.x and above -> always supported
+      }
+      if (majorVersion <= 1) {
+        return false;                                     // 1.x and below -> unsupported
+      }
+      // major == 2 -> supported from 2.3 onward
+      return tokens.length > 1 && Integer.parseInt(tokens[1]) >= 3;
+    } catch (NumberFormatException e) {
+      return false;                                       // unparsable version -> unsupported
+    }
   }
 
   // extract hive job url from logs, it only works for MR engine.

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/hive/HiveUtilsTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/hive/HiveUtilsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -50,5 +51,24 @@ public class HiveUtilsTest {
                     "(Executing on YARN cluster with App id application_1612885840821_260263)");
     assertTrue(appId.isPresent());
     assertEquals("application_1612885840821_260263", appId.get());
+  }
+
+  @Test
+  public void testIsProgressBarSupported() {
+    // null / blank versions
+    assertFalse(HiveUtils.isProgressBarSupported(null));
+    assertFalse(HiveUtils.isProgressBarSupported(""));
+    // supported only from Hive 2.3 (HIVE-16045)
+    assertFalse(HiveUtils.isProgressBarSupported("2"));
+    assertFalse(HiveUtils.isProgressBarSupported("2.2"));
+    assertTrue(HiveUtils.isProgressBarSupported("2.3"));
+    assertTrue(HiveUtils.isProgressBarSupported("3.1.3"));
+    assertFalse(HiveUtils.isProgressBarSupported("1.2.1"));
+    // versions with a trailing qualifier or a missing minor segment
+    assertTrue(HiveUtils.isProgressBarSupported("2.3-dev"));
+    assertTrue(HiveUtils.isProgressBarSupported("3-cdh"));
+    // real-world releases up to 2026 (both on Maven Central)
+    assertTrue(HiveUtils.isProgressBarSupported("4.2.0"));         // latest Apache Hive
+    assertTrue(HiveUtils.isProgressBarSupported("4.0.0-beta-1"));  // Hive 4 pre-release
   }
 }


### PR DESCRIPTION
### What is this PR for?
`HiveUtils.isProgressBarSupported(String)` decides whether to show the Hive query progress bar by parsing the version returned by `HiveVersionInfo.getVersion()`. The previous implementation split the version on `.` and parsed the first two tokens with `Integer.parseInt` with no validation, so it threw for two version shapes that real Hive builds can produce:

- **Missing dot** (e.g. `"2"`): the split yields a single-element array, so reading `tokens[1]` throws `ArrayIndexOutOfBoundsException`.
- **Qualifier suffix** (e.g. `"3-cdh"`, `"2.3-dev"`): a numeric segment carries a trailing qualifier, so `Integer.parseInt` throws `NumberFormatException`.

Either exception propagates into `startHiveMonitorThread()` and can break Hive job monitoring setup.

This PR makes the parser return a boolean for any input without throwing:
- strips any qualifier after the numeric version (`"3-cdh"` -> `"3"`, `"2.3-dev"` -> `"2.3"`),
- treats a missing minor segment as absent (`"3"` -> major 3 = supported, `"2"` -> major 2 with no minor = not supported),
- returns `false` for null / blank / otherwise unparsable versions.

The support rule is unchanged (progress bar is supported from Hive 2.3, HIVE-16045); it is only made robust and expressed as explicit tiers: major >= 3 always supported, major <= 1 unsupported, major == 2 depends on minor >= 3.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6479

### How should this be tested?
`./mvnw test -pl jdbc -Dtest=HiveUtilsTest`

The new `testIsProgressBarSupported` calls `HiveUtils.isProgressBarSupported` directly — the method is made package-private to match its sibling helpers in the same class (`extractMRJobURL`, `extractTezAppId`), which are already package-private and unit-tested the same way (no reflection). Testing through the only caller (`startHiveMonitorThread`) is not practical because the version is obtained internally from `HiveVersionInfo.getVersion()` and the method needs a live `HiveStatement`, so the edge-case versions cannot be injected. Cases cover the 2.3 boundary, both failure modes, null/blank input, and recent Maven Central releases (Hive 4.2.0 and 4.0.0-beta-1).

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
