### PR TITLE
[ZEPPELIN-6502] Replace deprecated openjdk Docker image with Eclipse Temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM openjdk:11 as builder
+FROM eclipse-temurin:11-jdk AS builder
 ADD . /workspace/zeppelin
 WORKDIR /workspace/zeppelin
 ENV MAVEN_OPTS="-Xms1024M -Xmx2048M -XX:MaxMetaspaceSize=1024m -XX:-UseGCOverheadLimit -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"


### PR DESCRIPTION
### What is this PR for?
 The root `Dockerfile` used the `openjdk:11` base image for its build stage, but that image is deprecated on Docker Hub and no longer receives updates. This PR replaces it with `eclipse-temurin:11-jdk`, the community-recommended drop-in successor, and uppercases the `AS` keyword to match modern Dockerfile (BuildKit) convention


### What type of PR is it?
Improvement

### Todos
* [x] Replace `FROM openjdk:11 as builder` with `FROM eclipse-temurin:11-jdk AS builder` 

### What is the Jira issue?
[ZEPPELIN-6502](https://issues.apache.org/jira/browse/ZEPPELIN-6502)

### How should this be tested?
* `docker build --check -f Dockerfile .` — confirms the image resolves and the Dockerfile has no lint warnings                                                                                                         
* Optionally run a full `docker build -f Dockerfile .` to confirm the image still builds and produces a working Zeppelin distribution

### Screenshots (if appropriate)
N/A (Dockerfile change, no UI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
