### PR TITLE
[ZEPPELIN-6444] Add type guard for imported note JSON to remove @ts-ignore

### DIFF
--- a/zeppelin-web-angular/src/app/share/note-import/note-import.component.ts
+++ b/zeppelin-web-angular/src/app/share/note-import/note-import.component.ts
@@ -20,6 +20,14 @@ import { NzUploadFile } from 'ng-zorro-antd/upload';
 import { MessageListener, MessageListenersManager } from '@zeppelin/core';
 import { ImportNote, MessageReceiveDataTypeMap, OP } from '@zeppelin/sdk';
 
+const isImportNote = (value: unknown): value is ImportNote['note'] => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const { paragraphs } = value as { paragraphs?: unknown };
+  return Array.isArray(paragraphs) && paragraphs.length > 0;
+};
+
 @Component({
   selector: 'zeppelin-note-import',
   templateUrl: './note-import.component.html',
@@ -83,16 +91,13 @@ export class NoteImportComponent extends MessageListenersManager implements OnIn
         return;
       }
     }
-    // @ts-ignore
-    if (result.paragraphs && result.paragraphs.length > 0) {
+    if (isImportNote(result)) {
       if (!this.noteImportName) {
-        // @ts-ignore
         this.noteImportName = result.name;
       } else {
-        // @ts-ignore
         result.name = this.noteImportName;
       }
-      this.messageService.importNote(result as ImportNote['note']);
+      this.messageService.importNote(result);
     } else {
       this.errorText = 'Invalid JSON';
     }

--- a/zeppelin-web-angular/src/app/share/note-import/note-import.component.ts
+++ b/zeppelin-web-angular/src/app/share/note-import/note-import.component.ts
@@ -19,14 +19,10 @@ import { NzUploadFile } from 'ng-zorro-antd/upload';
 
 import { MessageListener, MessageListenersManager } from '@zeppelin/core';
 import { ImportNote, MessageReceiveDataTypeMap, OP } from '@zeppelin/sdk';
+import { isRecord } from '@zeppelin/utility';
 
-const isImportNote = (value: unknown): value is ImportNote['note'] => {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-  const { paragraphs } = value as { paragraphs?: unknown };
-  return Array.isArray(paragraphs) && paragraphs.length > 0;
-};
+const isImportNote = (value: unknown): value is ImportNote['note'] =>
+  isRecord(value) && Array.isArray(value.paragraphs) && value.paragraphs.length > 0;
 
 @Component({
   selector: 'zeppelin-note-import',


### PR DESCRIPTION
### What is this PR for?
`NoteImportComponent` parsed unknown JSON and used three `@ts-ignore` comments to access `result.paragraphs` and `result.name`.

This PR adds a small `isImportNote()` type guard that narrows the parsed value to `ImportNote['note']`, so the paragraph check, the note-name override, and the `messageService.importNote()` call are all type-safe without suppressing the compiler.

### What type of PR is it?
Improvement

### Todos
* [x] Remove the `@ts-ignore` comments in `NoteImportComponent`
* [x] Keep the existing error behavior for invalid / non-note JSON
* [x] Preserve the imported note name override behavior

### What is the Jira issue?
[ZEPPELIN-6444](https://issues.apache.org/jira/browse/ZEPPELIN-6444)

### How should this be tested?
* `cd zeppelin-web-angular && npm run lint` passes.
* Import a valid note JSON (with a non-empty `paragraphs` array) — the note imports; leaving the name field empty keeps the note's original name, filling it overrides the name.
* Import a valid-but-not-a-note JSON (no `paragraphs`) — still shows "Invalid JSON".
* Import a malformed JSON payload — still shows "JSON parse exception".

### Questions:
* Does the license files need to be updated? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No