### PR TITLE
[ZEPPELIN-6550] Fix trash detection in note view so trashed notes can be permanently deleted

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
@@ -268,6 +268,7 @@ export class NotebookActionBarComponent extends MessageListenersManager implemen
 
   deleteNote() {
     this.messageService.deleteNote(this.note.id);
+    this.router.navigate(['/']);
   }
 
   moveNoteToTrash() {

--- a/zeppelin-web-angular/src/app/services/note-status.service.ts
+++ b/zeppelin-web-angular/src/app/services/note-status.service.ts
@@ -33,8 +33,10 @@ export class NoteStatusService {
   }
 
   isTrash(note: Exclude<Note['note'], undefined>) {
-    // TODO(hsuanxyz) https://github.com/apache/zeppelin/pull/3365/files
-    return note.name.split('/')[1] === this.TRASH_FOLDER_ID;
+    // Detect trash by note.path, not note.name: the trash folder is the second
+    // path segment (see apache/zeppelin#3365), and since ZEPPELIN-4041 note.name
+    // holds only the last path segment. Mirrors NoteListService.
+    return note.path.split('/')[1] === this.TRASH_FOLDER_ID;
   }
 
   viewOnly(note: Exclude<Note['note'], undefined>): boolean {


### PR DESCRIPTION
### What is this PR for?

In the new Angular UI, opening a note that lives in the Trash showed the normal **Move to trash** action instead of **Remove permanently**, so a trashed note could not be permanently deleted from the note view — confirming the action re-nested it deeper into Trash (`/~Trash/~Trash/...`). The cron scheduler button also stayed enabled for trashed notes.

Root cause: `NoteStatusService.isTrash` used `note.name.split('/')[1]`. Since ZEPPELIN-4041 the backend sets `Note.name` to the last path segment only (no `/`), so that index is always `undefined` and `isTrash` always returned `false`. The full path lives in `note.path`, which `NoteListService.setNotes` already uses correctly.

This PR:
- Uses `note.path` instead of `note.name` in `isTrash` (mirrors `NoteListService`).
- Navigates back to `/` after a permanent delete, matching `moveNoteToTrash`, so the view leaves the now-deleted note instead of re-fetching it and surfacing a 404.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6550

### How should this be tested?
* `cd zeppelin-web-angular && npm run lint`
* Create a note, move it to Trash, open it from the Trash, and confirm the action bar offers **Remove permanently** (not re-trash) and that the cron button is disabled. Confirming the permanent delete removes the note and returns to the home view without a 404.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)