### PR TITLE
[ZEPPELIN-6558] Drop the redundant Chromium-channel Playwright projects from CI

### DIFF
--- a/zeppelin-web-angular/playwright.config.js
+++ b/zeppelin-web-angular/playwright.config.js
@@ -48,16 +48,6 @@ module.exports = defineConfig({
       dependencies: ['setup']
     },
     {
-      name: 'Google Chrome',
-      use: {
-        ...devices['Desktop Chrome'],
-        channel: 'chrome',
-        permissions: ['clipboard-read', 'clipboard-write'],
-        storageState: 'playwright/.auth/user.json'
-      },
-      dependencies: ['setup']
-    },
-    {
       name: 'firefox',
       use: {
         ...devices['Desktop Firefox'],
@@ -72,16 +62,6 @@ module.exports = defineConfig({
         launchOptions: {
           slowMo: 200
         },
-        storageState: 'playwright/.auth/user.json'
-      },
-      dependencies: ['setup']
-    },
-    {
-      name: 'Microsoft Edge',
-      use: {
-        ...devices['Desktop Edge'],
-        channel: 'msedge',
-        permissions: ['clipboard-read', 'clipboard-write'],
         storageState: 'playwright/.auth/user.json'
       },
       dependencies: ['setup']


### PR DESCRIPTION
### What is this PR for?

`zeppelin-web-angular/playwright.config.js` declared five browser projects, three of them Chromium — the bundled build plus the `chrome` and `msedge` channels — so the e2e suite ran against Chromium three times per invocation. `run-playwright-e2e-tests (auth)` at ~53m is the critical path of the hour-long `frontend` workflow.

ZEPPELIN-6314 set the goal as "Multi-browser support: Chromium / Firefox / WebKit" — three engines. Nothing under `e2e/` references the `Google Chrome` or `Microsoft Edge` projects, nor the `chrome`/`msedge` channels; every browser-specific branch keys on `webkit` or `firefox` (`dark-mode.spec.ts`, `notebook-keyboard-shortcuts.spec.ts`, `editor-search-page.ts`). The two channel projects add a 3x Chromium pass without adding engine coverage.

This drops them, keeping `setup`, `chromium`, `firefox`, and `webkit`. WebKit is untouched, so ZEPPELIN-6450 is unaffected. `playwright.classic.config.js` is unaffected — it uses a single Chrome project. Follow-up from the review discussion on #5335.

### What type of PR is it?

Improvement

### What is the Jira issue?

[ZEPPELIN-6558](https://issues.apache.org/jira/browse/ZEPPELIN-6558)

### How should this be tested?

`frontend` workflow runs the Playwright e2e suite. Expect `run-playwright-e2e-tests (auth)` to drop from ~53m to ~27m with Chromium / Firefox / WebKit coverage retained.

### Questions:

* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
