### PR TITLE
[ZEPPELIN-6548] Use specific exceptions for Spark Scala fallback detection

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -318,10 +318,10 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
     }
     
     if (sparkReplJars.isEmpty()) {
-      throw new Exception("No spark-repl jar found in SPARK_HOME: " + sparkHome);
+      throw new IOException("No spark-repl jar found in SPARK_HOME: " + sparkHome);
     }
     if (sparkReplJars.size() > 1) {
-      throw new Exception("Multiple spark-repl jar found in SPARK_HOME: " + sparkHome);
+      throw new IOException("Multiple spark-repl jar found in SPARK_HOME: " + sparkHome);
     }
     
     String fileName = sparkReplJars.get(0).getFileName().toString();
@@ -330,7 +330,7 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
     } else if (fileName.contains("spark-repl_2.13")) {
       return "2.13";
     } else {
-      throw new Exception("Can not detect the scala version by spark-repl");
+      throw new IllegalArgumentException("Can not detect the scala version by spark-repl");
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

This PR refines exception types in `SparkInterpreterLauncher` when the fallback Spark Scala version detection validates the `SPARK_HOME/jars` layout.

Previously, `detectSparkScalaVersionByReplClass(...)` threw generic `Exception` for expected validation failures such as missing or duplicate `spark-repl` jars, or an unsupported `spark-repl` Scala suffix. This PR replaces those generic throw sites with more specific exception types while keeping the existing messages and caller behavior unchanged.

Missing or duplicate `spark-repl` jars now throw `IOException`, and an unrecognized Scala suffix now throws `IllegalArgumentException`.

This PR is a follow-up to [ZEPPELIN-6464](https://issues.apache.org/jira/browse/ZEPPELIN-6464)

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6548

### How should this be tested?
- Build and run the module tests:
```
./mvnw test -pl zeppelin-server --am
```

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No