### PR TITLE
[ZEPPELIN-6447] Add Module Federation typing for the published paragr…

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/published/paragraph/paragraph.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/published/paragraph/paragraph.component.ts
@@ -30,6 +30,7 @@ import {
   ParagraphIResultsMsgItem
 } from '@zeppelin/sdk';
 import { HeliumService, MessageService, NgZService, NoteStatusService } from '@zeppelin/services';
+import { RemoteContainer } from '@zeppelin/share';
 import { SpellResult } from '@zeppelin/spell';
 import { isNil } from 'lodash';
 import { NzModalService } from 'ng-zorro-antd/modal';
@@ -222,8 +223,7 @@ export class PublishedParagraphComponent extends ParagraphBase implements Publis
     }
 
     const loadModule = async () => {
-      // @ts-ignore
-      const container = window.reactApp;
+      const container: RemoteContainer | undefined = window.reactApp;
       if (!container) {
         throw new Error('window.reactApp not available');
       }

--- a/zeppelin-web-angular/src/app/share/react-mount/react-remote-loader.service.ts
+++ b/zeppelin-web-angular/src/app/share/react-mount/react-remote-loader.service.ts
@@ -14,7 +14,7 @@ import { Injectable } from '@angular/core';
 import { environment } from '../../../environments/environment';
 import { AnyExposedModule } from './react-mount-handle';
 
-interface RemoteContainer {
+export interface RemoteContainer {
   get<T>(key: string): Promise<() => T>;
   init?: (shareScope: unknown) => Promise<void>;
 }


### PR DESCRIPTION
### What is this PR for?
`PublishedParagraphComponent.loadReactWidget()` read the global Module Federation container via `window.reactApp` behind a `@ts-ignore` comment, so the compiler couldn't check the `container.get(...)` call that follows it.

`ReactRemoteLoaderService` already declares this container's shape as `RemoteContainer` and augments `Window.reactApp` with it globally. This PR exports that existing interface and reuses it here instead of adding a second, possibly conflicting `Window.reactApp` typing.


### What type of PR is it?
Improvement

### Todos
  * [x] Remove the `@ts-ignore` comment near `window.reactApp`
  * [x] Type the container with the existing `RemoteContainer` interface (covers the `get` API used here)
  * [x] Preserve the `window.reactApp not available` error when the container is missing

### What is the Jira issue?
 [ZEPPELIN-6447](https://issues.apache.org/jira/browse/ZEPPELIN-6447)

### How should this be tested?
  * `cd zeppelin-web-angular && npm run lint` passes with no new errors.
  * Load a published paragraph with `?react=true` and confirm the React widget still mounts; without the remote entry script, the "window.reactApp not available" error still surfaces.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
