### PR TITLE
[ZEPPELIN-6522] Guard HTTP interceptor unwrap against null response bodies

### DIFF
--- a/zeppelin-web-angular/src/app/app-http.interceptor.ts
+++ b/zeppelin-web-angular/src/app/app-http.interceptor.ts
@@ -32,7 +32,12 @@ export class AppHttpInterceptor implements HttpInterceptor {
     }
     return next.handle(httpRequestUpdated).pipe(
       map(event => {
-        if (event instanceof HttpResponse) {
+        if (
+          event instanceof HttpResponse &&
+          !isNil(event.body) &&
+          typeof event.body === 'object' &&
+          'body' in event.body
+        ) {
           return event.clone({ body: event.body.body });
         } else {
           return event;


### PR DESCRIPTION
### What is this PR for?
 `AppHttpInterceptor.intercept` unwraps every `HttpResponse` as `event.body.body`, assuming the Zeppelin REST envelope (`{status, message, body}`). When `event.body` is `null` — a 204 No Content, or any empty 200 response — evaluating `event.body.body` throws `TypeError: Cannot read properties of null (reading 'body')`, which propagates to every subscriber of that request and turns an otherwise-successful empty response into a failure.

Non-enveloped JSON and `responseType: 'text'` responses were never affected `event.body.body` is `undefined` for them, and `HttpResponse.clone()` keeps the original body when the update body is `undefined`. The defect was specific to the null-body case.

This PR guards the unwrap on `event.body` being a non-null object that actually carries a `body` field; any other response (including null-body) now passes through `event.clone()` unchanged instead of touching `.body` on it.


### What type of PR is it?
Bug Fix

### Todos
  * [x] Guard the unwrap so it only runs on a non-null object carrying a `body` field                                                                                                                                                   
  * [x] Verify enveloped responses still unwrap correctly                                                                                                                                                                               
  * [x] Verify null-body responses pass through without throwing

### What is the Jira issue?
  [ZEPPELIN-6522](https://issues.apache.org/jira/browse/ZEPPELIN-6522)

### How should this be tested?
  * `cd zeppelin-web-angular && npm run lint`
  * Feed the four body shapes (enveloped object, non-enveloped object, text string, null) through `event.clone({ body: event.body.body })` using a real `@angular/common/http` `HttpResponse`: before the fix, only the null case throws `TypeError: Cannot read properties of null (reading 'body')`; after the fix, all four pass through without throwing and the enveloped case still unwraps correctly.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
