### PR TITLE
[ZEPPELIN-6483] Format HDFS modification time in GMT to match the printed label

### DIFF
--- a/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Properties;
+import java.util.TimeZone;
 
 import org.apache.zeppelin.completer.CompletionType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -173,7 +174,11 @@ public class HDFSFileInterpreter extends FileInterpreter {
   }
 
   private String listDate(OneFileStatus fs) {
-    return new SimpleDateFormat("yyyy-MM-dd HH:mm").format(new Date(fs.modificationTime));
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+    // Format in GMT so the value matches the "GMT" label appended in listOne(),
+    // regardless of the JVM default time zone.
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+    return sdf.format(new Date(fs.modificationTime));
   }
 
   private String listOne(String path, OneFileStatus fs) {

--- a/file/src/test/java/org/apache/zeppelin/file/HDFSFileInterpreterTest.java
+++ b/file/src/test/java/org/apache/zeppelin/file/HDFSFileInterpreterTest.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.Gson;
 
@@ -30,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
+import java.util.TimeZone;
 
 import org.apache.zeppelin.completer.CompletionType;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -181,6 +183,26 @@ class HDFSFileInterpreterTest {
     assertEquals("No such File or directory", result.message().get(0).getData());
 
     t.close();
+  }
+
+  @Test
+  void testListDateFormatsInGmtToMatchLabel() {
+    // ZEPPELIN-6483: the timestamp must be formatted in GMT to match the trailing
+    // "GMT" label, regardless of the JVM default time zone.
+    TimeZone original = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+      HDFSFileInterpreter t = new MockHDFSFileInterpreter(new Properties());
+      t.open();
+      InterpreterResult result = t.interpret("ls -l /", null);
+      String out = result.message().get(0).getData();
+      // modificationTime 1438548219672 == 2015-08-02 20:43 GMT (2015-08-03 05:43 in KST)
+      assertTrue(out.contains("2015-08-02 20:43GMT"),
+          "modification time should be shown in GMT to match the label, but was:\n" + out);
+      t.close();
+    } finally {
+      TimeZone.setDefault(original);
+    }
   }
 
 }


### PR DESCRIPTION
### What is this PR for?
In the HDFS file interpreter, `listOne()` appends a hard-coded `GMT` label to the
modification time, but `listDate()` formats the timestamp using the JVM default
time zone. On any server not running in UTC, the displayed value does not match
the label (e.g. a file modified at `2015-08-02 20:43` GMT is shown as
`2015-08-03 05:43GMT` on a KST server).

This PR sets the formatter's time zone to GMT in `listDate()` so the rendered
value matches the existing label.

Why format in GMT (option A) rather than keep local time and fix the label (option B):
- `modificationTime` is an absolute epoch value, so the time zone is only a
  display choice. Formatting in GMT keeps the output identical regardless of the
  host/JVM default zone and consistent with the label already printed.
- Showing the interpreter JVM's local time would be ambiguous in shared HDFS /
  remote-interpreter, multi-user setups ("whose local time?"), and the output
  would vary per deployment, making it harder to reproduce and test.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Format the modification time in GMT in `listDate()`
* [x] - Add a regression test that runs under a non-UTC default zone (`Asia/Seoul`) and asserts the value is rendered in GMT to match the label

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6483

### How should this be tested?
* `./mvnw test -pl file -Dtest=HDFSFileInterpreterTest`
* The new test `testListDateFormatsInGmtToMatchLabel` pins a known `modificationTime` (1438548219672 = 2015-08-02 20:43 GMT) under an `Asia/Seoul` default zone and asserts the output contains `2015-08-02 20:43GMT`.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No — display-only change; on non-UTC servers the shown value changes, but it now correctly matches the label
* Does this needs documentation? No
