### PR TITLE
[ZEPPELIN-6462] Close interpreter-setting.json streams with try-with-resources

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -475,9 +475,8 @@ public class InterpreterSettingManager implements NoteEventListener {
     return appEventListener;
   }
 
-  boolean registerInterpreterFromResource(ClassLoader cl, String interpreterDir,
-                                          String interpreterJson, boolean override)
-      throws IOException {
+  private boolean registerInterpreterFromResource(ClassLoader cl, String interpreterDir,
+                                                  String interpreterJson, boolean override) throws IOException {
     URL[] urls = recursiveBuildLibList(new File(interpreterDir));
     ClassLoader tempClassLoader = new URLClassLoader(urls, null);
 
@@ -487,38 +486,26 @@ public class InterpreterSettingManager implements NoteEventListener {
     }
 
     LOGGER.debug("Reading interpreter-setting.json from {} as Resource", url);
-    try (InputStream stream = openStream(url)) {
+    try (InputStream stream = url.openStream()) {
       List<RegisteredInterpreter> registeredInterpreterList = getInterpreterListFromJson(stream);
       registerInterpreterSetting(registeredInterpreterList, interpreterDir, override);
     }
     return true;
   }
 
-  boolean registerInterpreterFromPath(String interpreterDir, String interpreterJson,
+  private boolean registerInterpreterFromPath(String interpreterDir, String interpreterJson,
       boolean override) throws IOException {
 
     Path interpreterJsonPath = Paths.get(interpreterDir, interpreterJson);
     if (Files.exists(interpreterJsonPath)) {
       LOGGER.debug("Reading interpreter-setting.json from file {}", interpreterJsonPath);
-      try (InputStream stream = openStream(interpreterJsonPath.toFile())) {
+      try (InputStream stream = new FileInputStream(interpreterJsonPath.toFile())) {
         List<RegisteredInterpreter> registeredInterpreterList = getInterpreterListFromJson(stream);
         registerInterpreterSetting(registeredInterpreterList, interpreterDir, override);
       }
       return true;
     }
     return false;
-  }
-
-  // allows a tracked stream to be injected in unit tests.
-  @VisibleForTesting
-  InputStream openStream(URL url) throws IOException {
-    return url.openStream();
-  }
-
-  // allows a tracked stream to be injected in unit tests.
-  @VisibleForTesting
-  InputStream openStream(File file) throws IOException {
-    return new FileInputStream(file);
   }
 
   private List<RegisteredInterpreter> getInterpreterListFromJson(InputStream stream) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -475,8 +475,9 @@ public class InterpreterSettingManager implements NoteEventListener {
     return appEventListener;
   }
 
-  private boolean registerInterpreterFromResource(ClassLoader cl, String interpreterDir,
-                                                  String interpreterJson, boolean override) throws IOException {
+  boolean registerInterpreterFromResource(ClassLoader cl, String interpreterDir,
+                                          String interpreterJson, boolean override)
+      throws IOException {
     URL[] urls = recursiveBuildLibList(new File(interpreterDir));
     ClassLoader tempClassLoader = new URLClassLoader(urls, null);
 
@@ -486,24 +487,38 @@ public class InterpreterSettingManager implements NoteEventListener {
     }
 
     LOGGER.debug("Reading interpreter-setting.json from {} as Resource", url);
-    List<RegisteredInterpreter> registeredInterpreterList =
-        getInterpreterListFromJson(url.openStream());
-    registerInterpreterSetting(registeredInterpreterList, interpreterDir, override);
+    try (InputStream stream = openStream(url)) {
+      List<RegisteredInterpreter> registeredInterpreterList = getInterpreterListFromJson(stream);
+      registerInterpreterSetting(registeredInterpreterList, interpreterDir, override);
+    }
     return true;
   }
 
-  private boolean registerInterpreterFromPath(String interpreterDir, String interpreterJson,
+  boolean registerInterpreterFromPath(String interpreterDir, String interpreterJson,
       boolean override) throws IOException {
 
     Path interpreterJsonPath = Paths.get(interpreterDir, interpreterJson);
     if (Files.exists(interpreterJsonPath)) {
       LOGGER.debug("Reading interpreter-setting.json from file {}", interpreterJsonPath);
-      List<RegisteredInterpreter> registeredInterpreterList =
-          getInterpreterListFromJson(new FileInputStream(interpreterJsonPath.toFile()));
-      registerInterpreterSetting(registeredInterpreterList, interpreterDir, override);
+      try (InputStream stream = openStream(interpreterJsonPath.toFile())) {
+        List<RegisteredInterpreter> registeredInterpreterList = getInterpreterListFromJson(stream);
+        registerInterpreterSetting(registeredInterpreterList, interpreterDir, override);
+      }
       return true;
     }
     return false;
+  }
+
+  // allows a tracked stream to be injected in unit tests.
+  @VisibleForTesting
+  InputStream openStream(URL url) throws IOException {
+    return url.openStream();
+  }
+
+  // allows a tracked stream to be injected in unit tests.
+  @VisibleForTesting
+  InputStream openStream(File file) throws IOException {
+    return new FileInputStream(file);
   }
 
   private List<RegisteredInterpreter> getInterpreterListFromJson(InputStream stream) {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.zeppelin.interpreter;
 
-import com.google.gson.JsonSyntaxException;
-
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
@@ -28,46 +26,23 @@ import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.repository.RemoteRepository;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.jar.JarEntry;
-import java.util.jar.JarOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 
 class InterpreterSettingManagerTest extends AbstractInterpreterTest {
-
-  private static final String INTERPRETER_SETTING_JSON = "interpreter-setting.json";
-
-  private static final String STREAM_TEST_SETTING =
-      "[{\"group\": \"stream_close_test\","
-          + " \"name\": \"stream_close_test\","
-          + " \"className\": \"org.apache.zeppelin.interpreter.EchoInterpreter\","
-          + " \"properties\": {}}]";
 
   private String note1Id;
   private String note2Id;
@@ -365,65 +340,6 @@ class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     } finally {
       System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_INCLUDES.getVarName());
       System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_EXCLUDES.getVarName());
-    }
-  }
-
-  @Test
-  void testRegisterInterpreterFromPathClosesStream(@TempDir Path interpreterDir)
-      throws IOException {
-    Files.write(interpreterDir.resolve(INTERPRETER_SETTING_JSON),
-        STREAM_TEST_SETTING.getBytes(StandardCharsets.UTF_8));
-
-    InterpreterSettingManager spyManager = spy(interpreterSettingManager);
-    InputStream stream = spy(
-        new ByteArrayInputStream(STREAM_TEST_SETTING.getBytes(StandardCharsets.UTF_8)));
-    doReturn(stream).when(spyManager).openStream(any(File.class));
-
-    assertTrue(spyManager.registerInterpreterFromPath(
-        interpreterDir.toString(), INTERPRETER_SETTING_JSON, false));
-
-    verify(stream).close();
-  }
-
-  @Test
-  void testRegisterInterpreterFromResourceClosesStream(@TempDir Path interpreterDir)
-      throws IOException {
-    // registerInterpreterFromResource builds a URLClassLoader over every file in the
-    // interpreter directory, so the setting has to be reachable from a jar entry.
-    writeSettingJar(interpreterDir.resolve("stream-close-test.jar"));
-
-    InterpreterSettingManager spyManager = spy(interpreterSettingManager);
-    InputStream stream = spy(
-        new ByteArrayInputStream(STREAM_TEST_SETTING.getBytes(StandardCharsets.UTF_8)));
-    doReturn(stream).when(spyManager).openStream(any(URL.class));
-
-    assertTrue(spyManager.registerInterpreterFromResource(
-        getClass().getClassLoader(), interpreterDir.toString(), INTERPRETER_SETTING_JSON, false));
-
-    verify(stream).close();
-  }
-
-  @Test
-  void testStreamIsClosedWhenParsingFails(@TempDir Path interpreterDir) throws IOException {
-    Files.write(interpreterDir.resolve(INTERPRETER_SETTING_JSON),
-        "not json".getBytes(StandardCharsets.UTF_8));
-
-    InterpreterSettingManager spyManager = spy(interpreterSettingManager);
-    InputStream stream = spy(
-        new ByteArrayInputStream("not json".getBytes(StandardCharsets.UTF_8)));
-    doReturn(stream).when(spyManager).openStream(any(File.class));
-
-    assertThrows(JsonSyntaxException.class, () -> spyManager.registerInterpreterFromPath(
-        interpreterDir.toString(), INTERPRETER_SETTING_JSON, false));
-
-    verify(stream).close();
-  }
-
-  private static void writeSettingJar(Path jarPath) throws IOException {
-    try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarPath))) {
-      jar.putNextEntry(new JarEntry(INTERPRETER_SETTING_JSON));
-      jar.write(STREAM_TEST_SETTING.getBytes(StandardCharsets.UTF_8));
-      jar.closeEntry();
     }
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.zeppelin.interpreter;
 
+import com.google.gson.JsonSyntaxException;
+
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
@@ -26,23 +28,46 @@ import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.repository.RemoteRepository;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 
 class InterpreterSettingManagerTest extends AbstractInterpreterTest {
+
+  private static final String INTERPRETER_SETTING_JSON = "interpreter-setting.json";
+
+  private static final String STREAM_TEST_SETTING =
+      "[{\"group\": \"stream_close_test\","
+          + " \"name\": \"stream_close_test\","
+          + " \"className\": \"org.apache.zeppelin.interpreter.EchoInterpreter\","
+          + " \"properties\": {}}]";
 
   private String note1Id;
   private String note2Id;
@@ -340,6 +365,65 @@ class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     } finally {
       System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_INCLUDES.getVarName());
       System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_EXCLUDES.getVarName());
+    }
+  }
+
+  @Test
+  void testRegisterInterpreterFromPathClosesStream(@TempDir Path interpreterDir)
+      throws IOException {
+    Files.write(interpreterDir.resolve(INTERPRETER_SETTING_JSON),
+        STREAM_TEST_SETTING.getBytes(StandardCharsets.UTF_8));
+
+    InterpreterSettingManager spyManager = spy(interpreterSettingManager);
+    InputStream stream = spy(
+        new ByteArrayInputStream(STREAM_TEST_SETTING.getBytes(StandardCharsets.UTF_8)));
+    doReturn(stream).when(spyManager).openStream(any(File.class));
+
+    assertTrue(spyManager.registerInterpreterFromPath(
+        interpreterDir.toString(), INTERPRETER_SETTING_JSON, false));
+
+    verify(stream).close();
+  }
+
+  @Test
+  void testRegisterInterpreterFromResourceClosesStream(@TempDir Path interpreterDir)
+      throws IOException {
+    // registerInterpreterFromResource builds a URLClassLoader over every file in the
+    // interpreter directory, so the setting has to be reachable from a jar entry.
+    writeSettingJar(interpreterDir.resolve("stream-close-test.jar"));
+
+    InterpreterSettingManager spyManager = spy(interpreterSettingManager);
+    InputStream stream = spy(
+        new ByteArrayInputStream(STREAM_TEST_SETTING.getBytes(StandardCharsets.UTF_8)));
+    doReturn(stream).when(spyManager).openStream(any(URL.class));
+
+    assertTrue(spyManager.registerInterpreterFromResource(
+        getClass().getClassLoader(), interpreterDir.toString(), INTERPRETER_SETTING_JSON, false));
+
+    verify(stream).close();
+  }
+
+  @Test
+  void testStreamIsClosedWhenParsingFails(@TempDir Path interpreterDir) throws IOException {
+    Files.write(interpreterDir.resolve(INTERPRETER_SETTING_JSON),
+        "not json".getBytes(StandardCharsets.UTF_8));
+
+    InterpreterSettingManager spyManager = spy(interpreterSettingManager);
+    InputStream stream = spy(
+        new ByteArrayInputStream("not json".getBytes(StandardCharsets.UTF_8)));
+    doReturn(stream).when(spyManager).openStream(any(File.class));
+
+    assertThrows(JsonSyntaxException.class, () -> spyManager.registerInterpreterFromPath(
+        interpreterDir.toString(), INTERPRETER_SETTING_JSON, false));
+
+    verify(stream).close();
+  }
+
+  private static void writeSettingJar(Path jarPath) throws IOException {
+    try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(jarPath))) {
+      jar.putNextEntry(new JarEntry(INTERPRETER_SETTING_JSON));
+      jar.write(STREAM_TEST_SETTING.getBytes(StandardCharsets.UTF_8));
+      jar.closeEntry();
     }
   }
 }


### PR DESCRIPTION
### What is this PR for?

`InterpreterSettingManager` discovers interpreters by reading each interpreter's `interpreter-setting.json`. Two helpers do this, and neither closes the stream it opens:

```java
// registerInterpreterFromResource
getInterpreterListFromJson(url.openStream());

// registerInterpreterFromPath
getInterpreterListFromJson(new FileInputStream(interpreterJsonPath.toFile()));
```

The shared sink wraps the stream in an `InputStreamReader` and hands it to `gson.fromJson(...)`. Gson does not close a reader passed to it — the caller owns it — so the descriptor leaks on the normal path. There is no `finally` or try-with-resources either, so it also leaks when parsing throws, for example a `JsonSyntaxException` from a malformed setting file.

This is not limited to startup. After installing an interpreter through `POST /api/interpreter/install`, `InterpreterService.downloadInterpreter()` calls `refreshInterpreterTemplates()`, which re-runs the whole directory scan. Every install therefore leaks one descriptor per interpreter directory, and the leaks accumulate on a long-running server.

This PR wraps each stream in a try-with-resources at the call site that opens it. Parsing and registration behaviour is unchanged. No signatures or access modifiers change.

### What type of PR is it?
Bug Fix

### Todos
* [x] Close the stream opened in `registerInterpreterFromResource`
* [x] Close the stream opened in `registerInterpreterFromPath`

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6462

### How should this be tested?

```bash
./mvnw package -pl zeppelin-server --am \
  -Dtest='InterpreterSettingManagerTest,InterpreterFactoryTest,InterpreterSettingTest' \
  -DfailIfNoTests=false
```

`Tests run: 26, Failures: 0, Errors: 0, Skipped: 0`, and `zeppelin-server` builds.

No tests accompany this change. Asserting that a stream is closed requires a seam in production code to inject a tracked stream, and an earlier revision of this PR added one — that is not worth carrying for a two-line fix, so it has been removed along with the tests that used it. The remaining change is the try-with-resources itself.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

