### PR TITLE
[ZEPPELIN-3225] Add missing @Override annotations in zeppelin-server

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
@@ -96,6 +96,7 @@ public class HeliumConf implements JsonSerializable {
     bundleDisplayOrder = Collections.synchronizedList(orderedPackageList);
   }
 
+  @Override
   public String toJson() {
     return gson.toJson(this);
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/helium/NpmPackage.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/helium/NpmPackage.java
@@ -31,6 +31,7 @@ public class NpmPackage implements JsonSerializable {
   public String version;
   public Map<String, String> dependencies;
 
+  @Override
   public String toJson() {
     return gson.toJson(this);
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/helium/WebpackResult.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/helium/WebpackResult.java
@@ -28,6 +28,7 @@ public class WebpackResult implements JsonSerializable {
   public final String [] errors = new String[0];
   public final String [] warnings = new String[0];
 
+  @Override
   public String toJson() {
     return gson.toJson(this);
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/socket/WatcherMessage.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/socket/WatcherMessage.java
@@ -40,6 +40,7 @@ public class WatcherMessage implements JsonSerializable {
     this.subject = builder.subject;
   }
   
+  @Override
   public String toJson() {
     return gson.toJson(this);
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/JsonExclusionStrategy.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/JsonExclusionStrategy.java
@@ -20,10 +20,12 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 
 public class JsonExclusionStrategy implements ExclusionStrategy {
+  @Override
   public boolean shouldSkipClass(Class<?> arg0) {
     return false;
   }
 
+  @Override
   public boolean shouldSkipField(FieldAttributes f) {
     return false;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/user/CredentialsInfoSaving.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/user/CredentialsInfoSaving.java
@@ -30,6 +30,7 @@ public class CredentialsInfoSaving implements JsonSerializable {
 
   public Map<String, UserCredentials> credentialsMap;
 
+  @Override
   public String toJson() {
     return GSON.toJson(this);
   }


### PR DESCRIPTION
### What is this PR for?
The original report is about missing @Override annotations in
ActiveDirectoryGroupRealm. Those were already added by ZEPPELIN-5130, so the
class is clean on current master.

To close out the issue with something useful, I scanned the whole
zeppelin-server module for methods that implement or override a supertype
method without the annotation, and found seven remaining cases:

* five `toJson()` implementations of `JsonSerializable`
  (`HeliumConf`, `NpmPackage`, `WebpackResult`, `WatcherMessage`,
  `CredentialsInfoSaving`)
* `shouldSkipClass` and `shouldSkipField` in `JsonExclusionStrategy`,
  which implement Gson's `ExclusionStrategy`

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3225

### How should this be tested?
Annotation only change with no behaviour change, so the compiler is the check.
`./mvnw compile -pl zeppelin-server` passes, RAT reports 0 unapproved licenses,
and Checkstyle reports no new violations in the touched files.

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
