### PR TITLE
[ZEPPELIN-6489] Fix stale Shiro authentication documentation links

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -30,7 +30,7 @@ user3 = password4, role2
 #activeDirectoryRealm = org.apache.zeppelin.realm.ActiveDirectoryGroupRealm
 #activeDirectoryRealm.systemUsername = userNameA
 
-#use either systemPassword or hadoopSecurityCredentialPath, more details in http://zeppelin.apache.org/docs/latest/security/shiroauthentication.html
+#use either systemPassword or hadoopSecurityCredentialPath, more details in https://zeppelin.apache.org/docs/latest/setup/security/shiro_authentication.html
 #activeDirectoryRealm.systemPassword = passwordA
 #activeDirectoryRealm.hadoopSecurityCredentialPath = jceks://file/user/zeppelin/zeppelin.jceks
 #activeDirectoryRealm.searchBase = CN=Users,DC=SOME_GROUP,DC=COMPANY,DC=COM

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/jwt/KnoxAuthenticationFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/jwt/KnoxAuthenticationFilter.java
@@ -68,8 +68,8 @@ public class KnoxAuthenticationFilter extends FormAuthenticationFilter {
       } else {
         LOGGER.error(
             "Looks like this filter is enabled without enabling KnoxJwtRealm, please refer"
-                + " to https://zeppelin.apache.org/docs/latest/security/shiroauthentication.html"
-                + "#knox-sso");
+                + " to https://zeppelin.apache.org/docs/latest/setup/security/"
+                + "shiro_authentication.html#knox-sso");
       }
     }
     return accessAllowed;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
@@ -77,7 +77,7 @@ public class KerberosAuthenticationFilter extends PassThruAuthenticationFilter {
     } else {
       LOGGER.error("Looks like this filter is enabled without enabling KerberosRealm, please refer"
           + " to https://zeppelin.apache.org/docs/latest/setup/security/shiro_authentication.html"
-          + "#kerberos-auth");
+          + "#http-spnego-authentication");
     }
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
@@ -76,7 +76,7 @@ public class KerberosAuthenticationFilter extends PassThruAuthenticationFilter {
       kerberosRealm.doKerberosAuth(request, response, filterChain);
     } else {
       LOGGER.error("Looks like this filter is enabled without enabling KerberosRealm, please refer"
-          + " to https://zeppelin.apache.org/docs/latest/security/shiroauthentication.html"
+          + " to https://zeppelin.apache.org/docs/latest/setup/security/shiro_authentication.html"
           + "#kerberos-auth");
     }
   }


### PR DESCRIPTION
### What is this PR for?
The Shiro authentication docs URL referenced in `conf/shiro.ini.template` and in the Kerberos/Knox authentication filter error messages no longer resolves. The stale link has three defects: it uses `http://` instead of `https://` (template only), the path is missing the `setup/` segment, and the file name is missing an underscore (`shiroauthentication.html` → `shiro_authentication.html`).

This PR updates all three pointers to the current docs address, which is published from `docs/setup/security/shiro_authentication.md`:

https://zeppelin.apache.org/docs/latest/setup/security/shiro_authentication.html

The surrounding comment/message text is unchanged. One line in `KnoxAuthenticationFilter` is re-wrapped to keep the longer URL within the 100-character checkstyle limit.

### What type of PR is it?
Documentation

### Todos
* [x] Update the stale URL in `conf/shiro.ini.template`, `KerberosAuthenticationFilter` and `KnoxAuthenticationFilter`

### What is the Jira issue?
* [ZEPPELIN-6489](https://issues.apache.org/jira/browse/ZEPPELIN-6489)

### How should this be tested?
No code behavior changes — the URLs appear only in a config template comment and log messages, so no unit tests are added.

* Confirm the source page exists at `docs/setup/security/shiro_authentication.md`
* Confirm no stale variants remain:
  ```
  rg -n "shiroauthentication|docs/latest/security/shiro|http://zeppelin.apache.org/docs/latest/security" conf zeppelin-server
  ```
* Open https://zeppelin.apache.org/docs/latest/setup/security/shiro_authentication.html and confirm it loads (verified: HTTP 200)

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
