### PR TITLE
[ZEPPELIN-6466] Improve RepositorySystemFactory error reporting

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/RepositorySystemFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/RepositorySystemFactory.java
@@ -25,28 +25,30 @@ import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Get maven repository instance.
  */
 public class RepositorySystemFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RepositorySystemFactory.class);
+
   public static RepositorySystem newRepositorySystem() {
     DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
     locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class );
     locator.addService(TransporterFactory.class, FileTransporterFactory.class);
     locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
-    locator.setErrorHandler( new DefaultServiceLocator.ErrorHandler()
-    {
-        @Override
-        public void serviceCreationFailed( Class<?> type, Class<?> impl, Throwable exception )
-        {
-            exception.printStackTrace();
-        }
-    } );
+    locator.setErrorHandler(new DefaultServiceLocator.ErrorHandler() {
+      @Override
+      public void serviceCreationFailed(Class<?> type, Class<?> impl, Throwable exception) {
+        LOGGER.error("Service creation failed for type {} impl {}", type, impl, exception);
+      }
+    });
     RepositorySystem system = locator.getService(RepositorySystem.class);
     if (system == null) {
-        throw new RuntimeException();
+      throw new RuntimeException(
+          "Cannot create RepositorySystem (locator.getService returned null)");
     }
     return system;
   }


### PR DESCRIPTION
### What is this PR for?

  Replace `printStackTrace()` in `RepositorySystemFactory` with SLF4J error logging so service creation failures are handled through the configured logging framework.

  Also add a meaningful message to the `RuntimeException` thrown when `locator.getService(RepositorySystem.class)` returns null.

  ### What type of PR is it?

  Improvement

  ### Todos

  * [x] Replace `printStackTrace()` with SLF4J logging
  * [x] Add a descriptive exception message
  * [x] Build the shaded interpreter JAR

  ### What is the Jira issue?

  https://issues.apache.org/jira/browse/ZEPPELIN-6466

  ### How should this be tested?

  The following commands were run successfully:

  * `./mvnw test -pl zeppelin-interpreter --am`
    * 126 tests passed
  * `./mvnw clean package -pl zeppelin-interpreter,zeppelin-interpreter-shaded -DskipTests`
    * Build succeeded

  ### Screenshots (if appropriate)

  N/A

  ### Questions:

  * Does the license files need to update? No
  * Is there breaking changes for older versions? No
  * Does this needs documentation? No