### PR TITLE
[ZEPPELIN-6478] Log Groovy classpath discovery failures with throwable

### DIFF
--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
@@ -76,7 +76,7 @@ public class GroovyInterpreter extends Interpreter {
                 .getPath());
         classes = new File(jar.getParentFile(), "classes").toString();
       } catch (Exception e) {
-        LOGGER.error(e.getMessage());
+        LOGGER.error("Failed to resolve Groovy classpath", e);
       }
     }
     LOGGER.info("groovy classes classpath: " + classes);


### PR DESCRIPTION
### What is this PR for?

  Pass the caught exception to SLF4J when Groovy classpath discovery fails in `GroovyInterpreter.open()`.

  Previously, only `e.getMessage()` was logged, so the exception stack trace was lost. This change logs a descriptive message together with the throwable while preserving the existing non-fatal fallback behavior.

  ### What type of PR is it?

  Improvement

  ### Todos

  * [x] Pass the classpath discovery exception to SLF4J
  * [x] Preserve the existing non-fatal control flow
  * [x] Run the Groovy module test lifecycle

  ### What is the Jira issue?

  https://issues.apache.org/jira/browse/ZEPPELIN-6478

  ### How should this be tested?

  The following command completed successfully:

  * `./mvnw test -pl groovy`
    * Build succeeded

  ### Screenshots (if appropriate)

  N/A

  ### Questions:

  * Does the license files need to update? No
  * Is there breaking changes for older versions? No
  * Does this needs documentation? No