### PR TITLE
[ZEPPELIN-6477] Stop dumping stack trace on Groovy cancellation

### DIFF
--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
@@ -196,7 +196,6 @@ public class GroovyInterpreter extends Interpreter {
       if (object instanceof Thread) {
         try {
           Thread t = (Thread) object;
-          t.dumpStack();
           t.interrupt();
           //t.stop(); //TODO(dlukyanov): need some way to terminate maybe through GObject..
         } catch (Throwable t) {


### PR DESCRIPTION
### What is this PR for?

  Remove the `Thread.dumpStack()` call from Groovy paragraph cancellation because it writes an unnecessary stack trace directly to stderr.

  The existing `t.interrupt()` call is preserved, so the paragraph cancellation behavior remains unchanged.

  ### What type of PR is it?

  Improvement

  ### Todos

  * [x] Remove the unnecessary stack dump
  * [x] Preserve the thread interruption behavior
  * [x] Run the Groovy module build and tests

  ### What is the Jira issue?

  https://issues.apache.org/jira/browse/ZEPPELIN-6477

  ### How should this be tested?

  ```bash
  ./mvnw test -pl groovy
  ```

  The build completed successfully.

  ### Screenshots (if appropriate)

  Not applicable.

  ### Questions:

  - Does the license files need to update? No
  - Is there breaking changes for older versions? No
  - Does this needs documentation? No