### PR TITLE
[ZEPPELIN-6480] Stop logging terminal dashboard HTML

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
@@ -176,7 +176,6 @@ public class TerminalInterpreter extends KerberosInterpreter {
     jinjaParams.put("TERMINAL_SERVER_URL", terminalServerUrl);
     String terminalDashboardTemplate = jinjava.render(template, jinjaParams);
 
-    LOGGER.info(terminalDashboardTemplate);
     try {
       intpContext.out.setType(InterpreterResult.Type.ANGULAR);
       InterpreterResultMessageOutput outputUI = intpContext.out.getOutputAt(0);


### PR DESCRIPTION
### What is this PR for?

  Remove the INFO log that writes the full rendered terminal dashboard HTML.

  The dashboard HTML is already written to the paragraph output, so logging it duplicates the content, adds unnecessary log volume, and exposes terminal URL parameters in logs.

  The paragraph output rendering behavior remains unchanged.

  ### What type of PR is it?

  Improvement

  ### Todos

  * [x] Remove the full dashboard HTML log
  * [x] Preserve the paragraph output rendering
  * [x] Run the shell module build and tests

  ### What is the Jira issue?

  https://issues.apache.org/jira/browse/ZEPPELIN-6480

  ### How should this be tested?

  ```bash
  ./mvnw test -pl shell

  The build completed successfully.

  ### Screenshots (if appropriate)

  Not applicable.

  ### Questions:

  - Does the license files need to update? No
  - Is there breaking changes for older versions? No
  - Does this needs documentation? No