### PR TITLE
[ZEPPELIN-6488] Refresh stale apache/zeppelin:0.10.0 Docker tags in the quickstart docs

### DIFF
--- a/docs/quickstart/install.md
+++ b/docs/quickstart/install.md
@@ -88,16 +88,18 @@ Make sure that [docker](https://www.docker.com/community-edition) is installed i
 Use this command to launch Apache Zeppelin in a container.
 
 ```bash
-docker run -p 8080:8080 --rm --name zeppelin apache/zeppelin:0.10.0
+docker run -p 8080:8080 --rm --name zeppelin apache/zeppelin:0.12.1
 
 ```
+
+The examples below pin the image to `0.12.1`. You can find the latest available tag on the [apache/zeppelin tags page](https://hub.docker.com/r/apache/zeppelin/tags) on Docker Hub.
 
 To persist `logs` and `notebook` directories, use the [volume](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only) option for docker container.
 
 ```bash
 docker run -u $(id -u) -p 8080:8080 --rm -v $PWD/logs:/logs -v $PWD/notebook:/notebook \
            -e ZEPPELIN_LOG_DIR='/logs' -e ZEPPELIN_NOTEBOOK_DIR='/notebook' \
-           --name zeppelin apache/zeppelin:0.10.0
+           --name zeppelin apache/zeppelin:0.12.1
 ```
 
 `-u $(id -u)` is to make sure you have the permission to write logs and notebooks. 
@@ -108,7 +110,7 @@ and Flink interpreter requires Flink binary distribution. You can also mount the
 ```bash
 docker run -u $(id -u) -p 8080:8080 --rm -v /mnt/disk1/notebook:/notebook \
 -v /usr/lib/spark-current:/opt/spark -v /mnt/disk1/flink-1.12.2:/opt/flink -e FLINK_HOME=/opt/flink  \
--e SPARK_HOME=/opt/spark  -e ZEPPELIN_NOTEBOOK_DIR='/notebook' --name zeppelin apache/zeppelin:0.10.0
+-e SPARK_HOME=/opt/spark  -e ZEPPELIN_NOTEBOOK_DIR='/notebook' --name zeppelin apache/zeppelin:0.12.1
 ```
 
 If you have trouble accessing `localhost:8080` in the browser, Please clear browser cache.


### PR DESCRIPTION
### What is this PR for?
The three `docker run` examples in the "Using the official docker image" section of `docs/quickstart/install.md` pin the image to `apache/zeppelin:0.10.0`, a release from several years ago. A first-time user following the Quickstart literally ends up running an image far behind the current docs.

This PR:
- updates the three examples to `apache/zeppelin:0.12.1`, the latest release tag currently available on Docker Hub
- adds a one-line note next to the examples pointing to the [apache/zeppelin tags page](https://hub.docker.com/r/apache/zeppelin/tags) so readers can find the latest tag, preventing the docs from silently rotting at the next release

Out of scope (open for discussion): the same stale tag also appears in `docs/interpreter/python.md`, `docs/interpreter/flink.md` (x2), `docs/interpreter/spark.md`, and `docs/interpreter/r.md`, and `docs/quickstart/docker.md` uses `FROM apache/zeppelin:0.8.0`. Would you prefer that I align those in this PR as well, or split them into a follow-up? I would be happy to do either.

### What type of PR is it?
Documentation

### What is the Jira issue?
* [ZEPPELIN-6488](https://issues.apache.org/jira/browse/ZEPPELIN-6488)

### How should this be tested?
Documentation-only change, no unit tests required.

* `grep -rn "apache/zeppelin:0.10.0" docs/quickstart/install.md` reports no occurrences
* Verified the updated command works: `docker run -p 8080:8080 --rm --name zeppelin apache/zeppelin:0.12.1` pulls the image and Zeppelin responds on the mapped port (`/api/version` returns `0.12.1`)

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No (this is a documentation change)
