### PR TITLE
[ZEPPELIN-6590] Bump websocket-driver to 0.7.5 to address CVE-2026-54466

### DIFF
--- a/zeppelin-web-angular/package-lock.json
+++ b/zeppelin-web-angular/package-lock.json
@@ -21423,9 +21423,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/zeppelin-web/package-lock.json
+++ b/zeppelin-web/package-lock.json
@@ -18638,9 +18638,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "dependencies": {
         "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
### What is this PR for?
The lockfiles of both web UIs (`zeppelin-web-angular` and `zeppelin-web`) resolve `websocket-driver` to 0.7.4, which is affected by [CVE-2026-54466 / GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6): the draft-75/76 frame parser accumulates the length header into an unbounded integer, so a client sending an indefinite sequence of continuation bytes (`0x80` or above) causes precision loss and mis-framing of subsequent payload data. The fix is in 0.7.5 (latest release), which closes the connection as soon as the accumulated length exceeds the configured max length.

`websocket-driver` is a dev-only transitive dependency (`@angular-devkit/build-angular` → `webpack-dev-server` → `sockjs` → `faye-websocket`), so shipped Zeppelin artifacts are not affected — but the vulnerable version keeps being flagged by dependency scanners.

Since `faye-websocket`'s constraint is `>=0.5.1` and `sockjs`'s is `^0.7.4`, this is a lockfile-only bump: each `package-lock.json` changes only the resolved `websocket-driver` entry (version / resolved / integrity). 0.7.4 and 0.7.5 declare identical dependencies, so no other entry changes.

Note: the dependabot security-update group PR #5354 covers `shell-quote` in the same directory but did not pick up `websocket-driver` (advisory published 2026-07-15, before that PR was created), presumably because it sits four levels deep in the dependency tree — hence this manual bump. The earlier bump attempt in #4798 (ZEPPELIN-6061, for a deprecation warning) was closed pending an Angular upgrade; master is on Angular 21 now, and this change does not touch `package.json` at all.

### What type of PR is it?
Improvement

### Todos
* [x] - Bump the `websocket-driver` lockfile entry to 0.7.5 in `zeppelin-web-angular/package-lock.json` and `zeppelin-web/package-lock.json`

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6590

### How should this be tested?
* `cd zeppelin-web-angular && npm ci` — installs cleanly and resolves `websocket-driver@0.7.5` (verified locally; `npm ls websocket-driver` shows a single 0.7.5 instance)
* CI web build should pass unchanged — dev-server behavior is unaffected (0.7.5 only adds a max-length guard in frame parsing)

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No