### PR TITLE
[ZEPPELIN-6483][FOLLOWUP] Format HDFS modification time with Locale.ROOT

### DIFF
--- a/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
@@ -27,6 +27,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -174,7 +175,9 @@ public class HDFSFileInterpreter extends FileInterpreter {
   }
 
   private String listDate(OneFileStatus fs) {
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+    // Locale.ROOT keeps the calendar and digits stable regardless of the JVM
+    // default locale (e.g. Buddhist calendar under th-TH).
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.ROOT);
     // Format in GMT so the value matches the "GMT" label appended in listOne(),
     // regardless of the JVM default time zone.
     sdf.setTimeZone(TimeZone.getTimeZone("GMT"));

--- a/file/src/test/java/org/apache/zeppelin/file/HDFSFileInterpreterTest.java
+++ b/file/src/test/java/org/apache/zeppelin/file/HDFSFileInterpreterTest.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -202,6 +203,27 @@ class HDFSFileInterpreterTest {
       t.close();
     } finally {
       TimeZone.setDefault(original);
+    }
+  }
+
+  @Test
+  void testListDateFormatsWithRootLocale() {
+    // ZEPPELIN-6483 follow-up: the timestamp must not depend on the JVM default
+    // locale either — under th-TH the CLDR default calendar is Buddhist, which
+    // would render 2015 as 2558 without Locale.ROOT in listDate().
+    Locale original = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("th-TH"));
+      HDFSFileInterpreter t = new MockHDFSFileInterpreter(new Properties());
+      t.open();
+      InterpreterResult result = t.interpret("ls -l /", null);
+      String out = result.message().get(0).getData();
+      // modificationTime 1438548219672 == 2015-08-02 20:43 GMT
+      assertTrue(out.contains("2015-08-02 20:43GMT"),
+          "modification time should not depend on the default locale, but was:\n" + out);
+      t.close();
+    } finally {
+      Locale.setDefault(original);
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
Follow-up to #5351, addressing the non-blocking nit from the [approving review](https://github.com/apache/zeppelin/pull/5351#pullrequestreview-4820385490): `new SimpleDateFormat(pattern)` still takes its calendar and digits from the JVM default *locale*, so the same class of environment dependence survives the GMT fix — e.g. under a `th-TH` default locale the Buddhist calendar renders 2015 as `2558-08-02 20:43GMT`.

This change passes `Locale.ROOT` to the formatter in `listDate()` so the calendar and digits are stable regardless of the JVM default locale, exactly as suggested in the review.

The new test mirrors the structure of `testListDateFormatsInGmtToMatchLabel` (save/restore of the global default in `finally`), switching the default locale to `th-TH` and asserting the listing still shows `2015-08-02 20:43GMT`. Reverting only the `listDate()` change makes it fail with the Buddhist-calendar output (`2558-08-02 20:43GMT`), so it pins the regression rather than asserting current behaviour.

### What type of PR is it?
Improvement

### Todos
* [x] - Pass `Locale.ROOT` to the `SimpleDateFormat` in `listDate()`
* [x] - Add a regression test that fails without the fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6483 (resolved by #5351; this is the follow-up allowed in its review)

### How should this be tested?
* `./mvnw test -pl file -Dtest=HDFSFileInterpreterTest` — 8 tests green (7 existing + 1 new)
* Verified locally that reverting only the `listDate()` change makes `testListDateFormatsWithRootLocale` fail with `2558-08-02 20:43GMT` (Buddhist calendar year) in the listing

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
