### PR TITLE
[ZEPPELIN-6459] Align Docker image logging configuration and documentation with Log4j2

### DIFF
--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -142,7 +142,8 @@ Zeppelin service runs on local server, it auto configure itself to use `DockerIn
  - ${ZEPPELIN_HOME}/interpreter/${interpreterGroupName}
  - ${ZEPPELIN_HOME}/conf/zeppelin-site.xml
  - ${ZEPPELIN_HOME}/conf/log4j.properties
- - ${ZEPPELIN\_HOME}/conf/log4j\_yarn_cluster.properties
+ - ${ZEPPELIN_HOME}/conf/log4j2.properties
+ - ${ZEPPELIN_HOME}/conf/log4j_yarn_cluster.properties
  - HADOOP\_CONF_DIR
  - SPARK\_CONF_DIR
  - /etc/krb5.conf

--- a/docs/setup/deployment/docker.md
+++ b/docs/setup/deployment/docker.md
@@ -40,6 +40,12 @@ docker run -p 8080:8080 -e ZEPPELIN_IN_DOCKER=true --rm --name zeppelin apache/z
 Notice, please specify environment variable `ZEPPELIN_IN_DOCKER` when starting zeppelin in docker, 
 otherwise you can not see the interpreter log.
 
+Note: `ZEPPELIN_IN_DOCKER` applies to the all-in-one image built from
+`scripts/docker/zeppelin/bin` (the `Dockerfile` referenced under "Building dockerfile
+locally" below). The split `zeppelin-server`/`zeppelin-interpreter` images described in
+"Build docker image for Zeppelin server & interpreters" already log to stdout by
+default and don't need or support this flag.
+
 * Zeppelin will run at `http://localhost:8080`.
 
 If you want to specify `logs` and `notebook` dir, 

--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -78,6 +78,11 @@ RUN echo "$LOG_TAG Download Zeppelin binary" && \
     chmod 775 ${ZEPPELIN_HOME} && \
     chmod -R 775 /opt/conda
 
+# These 4 files are all required by bin/common.sh, not obsolete duplicates:
+# log4j.properties / log4j_docker.properties configure reload4j, which backs the
+# server and most interpreters; log4j2.properties / log4j2_docker.properties
+# configure the real Log4j2 core that Flink bundles transitively. The "_docker"
+# variants are only picked up when the ZEPPELIN_IN_DOCKER env var is set.
 COPY log4j.properties ${ZEPPELIN_HOME}/conf/
 COPY log4j_docker.properties ${ZEPPELIN_HOME}/conf/
 COPY log4j2.properties ${ZEPPELIN_HOME}/conf/

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -547,7 +547,8 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     copyFiles.put(
         zeplConfPath + "/zeppelin-site.xml", containerZeplConfPath + "/zeppelin-site.xml");
     copyFiles.put(zeplConfPath + "/log4j.properties", containerZeplConfPath + "/log4j.properties");
-    copyFiles.put(zeplConfPath + "/log4j2.properties", containerZeplConfPath + "/log4j2.properties");
+    copyFiles.put(zeplConfPath + "/log4j2.properties",
+        containerZeplConfPath + "/log4j2.properties");
     copyFiles.put(zeplConfPath + "/log4j_yarn_cluster.properties",
         containerZeplConfPath + "/log4j_yarn_cluster.properties");
 

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -547,6 +547,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     copyFiles.put(
         zeplConfPath + "/zeppelin-site.xml", containerZeplConfPath + "/zeppelin-site.xml");
     copyFiles.put(zeplConfPath + "/log4j.properties", containerZeplConfPath + "/log4j.properties");
+    copyFiles.put(zeplConfPath + "/log4j2.properties", containerZeplConfPath + "/log4j2.properties");
     copyFiles.put(zeplConfPath + "/log4j_yarn_cluster.properties",
         containerZeplConfPath + "/log4j_yarn_cluster.properties");
 


### PR DESCRIPTION
### What is this PR for?
Docker-related scripts and docs still referenced Log4j 1.x style `log4j.properties`                                                                               files, and the reporter suspected these were obsolete leftovers from a Log4j2                                                                                       migration. Investigation showed the opposite: Zeppelin's default SLF4J binding is                                                                                   `slf4j-reload4j`, so `log4j.properties` is still the primary logging config, while                                                                                  `log4j2.properties` exists only for Flink's bundled real Log4j2 core — both are                                                                                    required, not obsolete.                                                                                                                                             
                                                                                                                                                                      
The real bug found: `DockerInterpreterProcess` (the `DockerInterpreterLauncher`                                                                                     feature) uploads `log4j.properties` and `log4j_yarn_cluster.properties` from the host                                                                               
to the interpreter container, but never `log4j2.properties`, even though                                                                                            `bin/common.sh` looks for it via `-Dlog4j.configurationFile` for every local                                                                                        interpreter process. This PR adds it to the transferred file list, aligns                                                                                           `docs/quickstart/docker.md`'s file list with the code, documents why                                                                                                `scripts/docker/zeppelin/bin/Dockerfile` needs all 4 log4j* files (so they aren't                                                                                   mistaken for duplicates again), and clarifies in                                                                                                                   `docs/setup/deployment/docker.md` that `ZEPPELIN_IN_DOCKER` applies to the all-in-one                                                                               image, not the split `zeppelin-server`/`zeppelin-interpreter` images.


### What type of PR is it?
Bug Fix


### Todos
 * [x] Add missing `log4j2.properties` to `DockerInterpreterProcess`'s container file                                                                               transfer list                                                                                                                                                     
  * [x] Sync `docs/quickstart/docker.md`'s transferred-file list with the code                                                                                        
  * [x] Document why `scripts/docker/zeppelin/bin/Dockerfile` ships 4 log4j* files                                                                                    
  * [x] Clarify `ZEPPELIN_IN_DOCKER` scope in `docs/setup/deployment/docker.md`

### What is the Jira issue?
[ZEPPELIN-6459](https://issues.apache.org/jira/browse/ZEPPELIN-6459)

### How should this be tested?
  * No existing unit test covers `DockerInterpreterProcess#copyRunFileToContainer`                                                                                    
    (it's private and untested), so no automated test was added for the transfer list                                                                                 
    itself; existing `DockerInterpreterProcessTest` (6 tests) still passes unchanged.                                                                                 
  * Manually verified: built the exact tar archive `DockerInterpreterProcess` produces                                                                                
    using the same `TarUtils`/`TarFileEntry` production classes with the fixed                                                                                        
    `copyFiles` entries, injected it into a real Alpine container via the same                                                                                        
    upload-tar-then-extract mechanism `deployToContainer` uses, and confirmed                                                                                         
    `log4j.properties`, `log4j2.properties`, and `log4j_yarn_cluster.properties` all                                                                                  
    land at the expected `conf/` path inside the container with content identical                                                                                     
    (byte-for-byte `diff`) to the host source files.

### Screenshots (if appropriate)
  N/A (docs/config change, no UI impact)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation?  Yes — `docs/quickstart/docker.md` and                                                                                             `docs/setup/deployment/docker.md` updated as part of this PR
