### PR TITLE
[ZEPPELIN-6486] Rename the mislabeled "Set up JDK 8" CI step to JDK 11

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -243,7 +243,7 @@ jobs:
         uses: actions/checkout@v5
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'


### PR DESCRIPTION
### What is this PR for?
The JDK setup step in the `flink-test-and-flink-integration-test` job of `.github/workflows/core.yml` was named "Set up JDK 8" while its `java-version` was already set to `11`. The name was the only thing wrong; anyone reading the workflow or the CI logs would think the job runs on JDK 8.

This renames the step to "Set up JDK 11", matching the correctly labeled step elsewhere in the same file. Only the display name changes — `java-version` and every other key stay exactly as they are.

A grep across `.github/workflows/` confirms this was the only static JDK setup step whose name disagreed with its configured `java-version`; every other step either pins 11 with a matching name or derives the version from the build matrix.

### What type of PR is it?
Improvement

### Todos
- [x] - Rename the step to "Set up JDK 11"

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6486

### How should this be tested?
`grep -rn "Set up JDK 8" .github/workflows/` returns no matches.
The renamed step still has `java-version: 11` and no other keys changed.
The workflow YAML still parses.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No