### PR TITLE
[ZEPPELIN-5934] Check folder permissions before rename, trash and remove

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -540,6 +540,10 @@ public class Notebook {
     return noteManager.containsFolder(folderPath);
   }
 
+  public List<NoteInfo> getNoteInfoRecursively(String folderPath) throws IOException {
+    return noteManager.getNoteInfoRecursively(folderPath);
+  }
+
   public void moveNote(String noteId, String newNotePath, AuthenticationInfo subject) throws IOException {
     LOGGER.info("Move note {} to {}", noteId, newNotePath);
     noteManager.moveNote(noteId, newNotePath, subject);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -715,6 +715,11 @@ public class NotebookService {
       return;
     }
     try {
+      // RESTORE_NOTE only asks for WRITER, so restoring a whole folder stays on the same level.
+      if (!checkFolderPermission(folderPath, Permission.WRITER, Message.OP.RESTORE_FOLDER,
+          context, callback)) {
+        return;
+      }
       String destFolderPath = folderPath.replace("/" + NoteManager.TRASH_FOLDER, "");
       notebook.moveFolder(folderPath, destFolderPath, context.getAutheInfo());
       callback.onSuccess(null, context);
@@ -1261,9 +1266,14 @@ public class NotebookService {
                               ServiceContext context,
                               ServiceCallback<Void> callback) throws IOException {
 
-    //TODO(zjffdu) folder permission check
     //TODO(zjffdu) folderPath is relative path, need to fix it in frontend
     LOGGER.info("Move folder {} to trash", folderPath);
+
+    String srcFolderPath = "/" + folderPath;
+    if (!checkFolderPermission(srcFolderPath, Permission.OWNER,
+        Message.OP.MOVE_FOLDER_TO_TRASH, context, callback)) {
+      return;
+    }
 
     String destFolderPath = "/" + NoteManager.TRASH_FOLDER + "/" + folderPath;
     if (notebook.containsNote(destFolderPath)) {
@@ -1271,7 +1281,7 @@ public class NotebookService {
           TRASH_CONFLICT_TIMESTAMP_FORMATTER.format(Instant.now());
     }
 
-    notebook.moveFolder("/" + folderPath, destFolderPath, context.getAutheInfo());
+    notebook.moveFolder(srcFolderPath, destFolderPath, context.getAutheInfo());
     callback.onSuccess(null, context);
   }
 
@@ -1291,6 +1301,10 @@ public class NotebookService {
                            ServiceContext context,
                            ServiceCallback<List<NoteInfo>> callback) throws IOException {
     try {
+      if (!checkFolderPermission(folderPath, Permission.OWNER, Message.OP.REMOVE_FOLDER,
+          context, callback)) {
+        return null;
+      }
       notebook.removeFolder(folderPath, context.getAutheInfo());
       List<NoteInfo> notesInfo = notebook.getNotesInfo(
               noteId -> authorizationService.isReader(noteId, context.getUserAndRoles()));
@@ -1306,10 +1320,13 @@ public class NotebookService {
                            String newFolderPath,
                            ServiceContext context,
                            ServiceCallback<List<NoteInfo>> callback) throws IOException {
-    //TODO(zjffdu) folder permission check
-
     try {
-      notebook.moveFolder(normalizeNotePath(folderPath),
+      String normalizedFolderPath = normalizeNotePath(folderPath);
+      if (!checkFolderPermission(normalizedFolderPath, Permission.OWNER,
+          Message.OP.FOLDER_RENAME, context, callback)) {
+        return null;
+      }
+      notebook.moveFolder(normalizedFolderPath,
               normalizeNotePath(newFolderPath), context.getAutheInfo());
       List<NoteInfo> notesInfo = notebook.getNotesInfo(
               noteId -> authorizationService.isReader(noteId, context.getUserAndRoles()));
@@ -1536,34 +1553,78 @@ public class NotebookService {
                                       Message.OP op,
                                       ServiceContext context,
                                       ServiceCallback<T> callback) throws IOException {
-    boolean isAllowed = false;
-    Set<String> allowed = null;
-    switch (permission) {
-      case READER:
-        isAllowed = authorizationService.isReader(noteId, context.getUserAndRoles());
-        allowed = authorizationService.getReaders(noteId);
-        break;
-      case WRITER:
-        isAllowed = authorizationService.isWriter(noteId, context.getUserAndRoles());
-        allowed = authorizationService.getWriters(noteId);
-        break;
-      case RUNNER:
-        isAllowed = authorizationService.isRunner(noteId, context.getUserAndRoles());
-        allowed = authorizationService.getRunners(noteId);
-        break;
-      case OWNER:
-        isAllowed = authorizationService.isOwner(noteId, context.getUserAndRoles());
-        allowed = authorizationService.getOwners(noteId);
-        break;
-    }
-    if (isAllowed) {
+    if (hasPermission(noteId, permission, context.getUserAndRoles())) {
       return true;
     } else {
       String errorMsg = "Insufficient privileges to " + permission + " note.\n" +
-          "Allowed users or roles: " + allowed + "\n" + "But the user " +
-          context.getAutheInfo().getUser() + " belongs to: " + context.getUserAndRoles();
+          "Allowed users or roles: " + getAllowedEntities(noteId, permission) + "\n" +
+          "But the user " + context.getAutheInfo().getUser() +
+          " belongs to: " + context.getUserAndRoles();
       callback.onFailure(new ForbiddenException(errorMsg), context);
       return false;
+    }
+  }
+
+  /**
+   * Zeppelin has no folder level ACL, so the permission of a folder is derived from the notes
+   * under it: the operation is allowed only when the caller holds the required permission on
+   * every one of them, and a folder holding no note is allowed.
+   *
+   * @return true when the operation may proceed, false after the callback has been failed
+   */
+  private <T> boolean checkFolderPermission(String folderPath,
+                                            Permission permission,
+                                            Message.OP op,
+                                            ServiceContext context,
+                                            ServiceCallback<T> callback) throws IOException {
+    List<String> deniedNotePaths = new ArrayList<>();
+    for (NoteInfo noteInfo : notebook.getNoteInfoRecursively(folderPath)) {
+      if (!hasPermission(noteInfo.getId(), permission, context.getUserAndRoles())) {
+        deniedNotePaths.add(noteInfo.getPath());
+      }
+    }
+    if (deniedNotePaths.isEmpty()) {
+      return true;
+    } else {
+      // Denied paths go to the log only: the caller may not be allowed to read those notes.
+      LOGGER.info("Permission check failed for {} on folder {}, user {} lacks {} on {}",
+          op, folderPath, context.getAutheInfo().getUser(), permission, deniedNotePaths);
+      String errorMsg = "Insufficient privileges to " + permission + " folder " + folderPath +
+          ".\n" + deniedNotePaths.size() + " of the notes it holds require " + permission +
+          " privileges.\n" + "But the user " + context.getAutheInfo().getUser() +
+          " belongs to: " + context.getUserAndRoles();
+      callback.onFailure(new ForbiddenException(errorMsg), context);
+      return false;
+    }
+  }
+
+  private boolean hasPermission(String noteId, Permission permission, Set<String> userAndRoles) {
+    switch (permission) {
+      case READER:
+        return authorizationService.isReader(noteId, userAndRoles);
+      case WRITER:
+        return authorizationService.isWriter(noteId, userAndRoles);
+      case RUNNER:
+        return authorizationService.isRunner(noteId, userAndRoles);
+      case OWNER:
+        return authorizationService.isOwner(noteId, userAndRoles);
+      default:
+        return false;
+    }
+  }
+
+  private Set<String> getAllowedEntities(String noteId, Permission permission) {
+    switch (permission) {
+      case READER:
+        return authorizationService.getReaders(noteId);
+      case WRITER:
+        return authorizationService.getWriters(noteId);
+      case RUNNER:
+        return authorizationService.getRunners(noteId);
+      case OWNER:
+        return authorizationService.getOwners(noteId);
+      default:
+        return Collections.emptySet();
     }
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -19,6 +19,7 @@
 package org.apache.zeppelin.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,6 +37,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -66,6 +68,7 @@ import org.apache.zeppelin.notebook.exception.NotePathAlreadyExistsException;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.VFSNotebookRepo;
 import org.apache.zeppelin.notebook.scheduler.QuartzSchedulerService;
+import org.apache.zeppelin.rest.exception.ForbiddenException;
 import org.apache.zeppelin.search.LuceneSearch;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.storage.ConfigStorage;
@@ -88,6 +91,7 @@ class NotebookServiceTest {
   private File confDir;
   private SearchService searchService;
   private Notebook notebook;
+  private AuthorizationService authorizationService;
   private ServiceContext context =
       new ServiceContext(AuthenticationInfo.ANONYMOUS, new HashSet<>());
 
@@ -136,8 +140,7 @@ class NotebookServiceTest {
     when(mockInterpreterSetting.getStatus()).thenReturn(InterpreterSetting.Status.READY);
     Credentials credentials = new Credentials();
     NoteManager noteManager = new NoteManager(notebookRepo, zConf);
-    AuthorizationService authorizationService =
-        new AuthorizationService(noteManager, zConf, storage);
+    authorizationService = new AuthorizationService(noteManager, zConf, storage);
     notebook =
         new Notebook(
             zConf,
@@ -408,6 +411,115 @@ class NotebookServiceTest {
 
     notesInfo = notebookService.listNotesInfo(false, context, callback);
     assertEquals(0, notesInfo.size());
+  }
+
+  @Test
+  void testFolderOperationsRequirePermissionOnEveryNote() throws IOException {
+    ServiceContext user1 = userContext("user1");
+    ServiceContext user2 = userContext("user2");
+
+    // note2 sits in a sub folder, so it is only reached by walking the folder recursively
+    String note1Id = notebookService.createNote("/folder_1/note1", "test", true, user1, callback);
+    String note2Id =
+        notebookService.createNote("/folder_1/nested/note2", "test", true, user1, callback);
+    // user2 owns one of the two notes
+    authorizationService.setOwners(note1Id, new HashSet<>(Arrays.asList("user1", "user2")));
+    assertTrue(authorizationService.isOwner(note1Id, user2.getUserAndRoles()));
+    assertFalse(authorizationService.isOwner(note2Id, user2.getUserAndRoles()));
+
+    reset(callback);
+    assertNull(notebookService.renameFolder("/folder_1", "/folder_2", user2, callback));
+    assertForbidden();
+
+    reset(callback);
+    notebookService.moveFolderToTrash("folder_1", user2, callback);
+    assertForbidden();
+
+    reset(callback);
+    assertNull(notebookService.removeFolder("/folder_1", user2, callback));
+    String errorMsg = assertForbidden();
+    // the message names the folder but not the note that blocked the call
+    assertTrue(errorMsg.contains("/folder_1"), errorMsg);
+    assertFalse(errorMsg.contains("note2"), errorMsg);
+
+    // nothing was applied
+    reset(callback);
+    List<NoteInfo> notesInfo = notebookService.listNotesInfo(false, user1, callback);
+    assertEquals(new HashSet<>(Arrays.asList("/folder_1/note1", "/folder_1/nested/note2")),
+        notesInfo.stream().map(NoteInfo::getPath).collect(Collectors.toSet()));
+
+    // the owner of every note succeeds
+    reset(callback);
+    notesInfo = notebookService.renameFolder("/folder_1", "/folder_2", user1, callback);
+    verify(callback).onSuccess(notesInfo, user1);
+    assertEquals(new HashSet<>(Arrays.asList("/folder_2/note1", "/folder_2/nested/note2")),
+        notesInfo.stream().map(NoteInfo::getPath).collect(Collectors.toSet()));
+
+    reset(callback);
+    notesInfo = notebookService.removeFolder("/folder_2", user1, callback);
+    verify(callback).onSuccess(notesInfo, user1);
+    assertEquals(0, notesInfo.size());
+  }
+
+  @Test
+  void testRestoreFolderRequiresWriterPermission() throws IOException {
+    ServiceContext user1 = userContext("user1");
+    ServiceContext user2 = userContext("user2");
+    ServiceContext user3 = userContext("user3");
+
+    String noteId = notebookService.createNote("/Backup/note1", "test", true, user1, callback);
+    // user2 may write the note, user3 may only read it
+    authorizationService.setWriters(noteId, new HashSet<>(Arrays.asList("user1", "user2")));
+    authorizationService.setReaders(noteId,
+        new HashSet<>(Arrays.asList("user1", "user2", "user3")));
+    assertTrue(authorizationService.isReader(noteId, user3.getUserAndRoles()));
+    assertFalse(authorizationService.isWriter(noteId, user3.getUserAndRoles()));
+    assertTrue(authorizationService.isWriter(noteId, user2.getUserAndRoles()));
+    notebookService.moveFolderToTrash("Backup", user1, callback);
+
+    // a reader is not enough
+    reset(callback);
+    notebookService.restoreFolder("/~Trash/Backup", user3, callback);
+    assertForbidden();
+
+    // a writer is, like RESTORE_NOTE
+    reset(callback);
+    notebookService.restoreFolder("/~Trash/Backup", user2, callback);
+    verify(callback).onSuccess(null, user2);
+    notebookService.getNote(noteId, user2, callback,
+        restoredNote -> {
+          assertEquals("/Backup/note1", restoredNote.getPath());
+          return null;
+        });
+  }
+
+  @Test
+  void testRemoveFolderHoldingNoNoteIsAllowed() throws IOException {
+    ServiceContext user1 = userContext("user1");
+    ServiceContext user2 = userContext("user2");
+
+    String noteId = notebookService.createNote("/folder_1/note1", "test", true, user1, callback);
+    // removing the last note leaves the folder itself in the tree
+    notebookService.removeNote(noteId, user1, callback);
+
+    reset(callback);
+    List<NoteInfo> notesInfo = notebookService.removeFolder("/folder_1", user2, callback);
+    verify(callback).onSuccess(notesInfo, user2);
+    assertEquals(0, notesInfo.size());
+  }
+
+  private ServiceContext userContext(String user) {
+    return new ServiceContext(new AuthenticationInfo(user),
+        new HashSet<>(Arrays.asList(user)));
+  }
+
+  // returns the message the caller would receive, to check what it does not reveal
+  private String assertForbidden() throws IOException {
+    ArgumentCaptor<Exception> exception = ArgumentCaptor.forClass(Exception.class);
+    verify(callback).onFailure(exception.capture(), any(ServiceContext.class));
+    assertTrue(exception.getValue() instanceof ForbiddenException,
+        "Expected a ForbiddenException but got: " + exception.getValue());
+    return ((ForbiddenException) exception.getValue()).getResponse().getEntity().toString();
   }
 
   @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -72,11 +73,13 @@ import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
+import org.apache.zeppelin.ticket.TicketContainer;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -921,6 +924,54 @@ class NotebookServerTest extends AbstractTestRestApi {
         notebook.removeNote(noteId, anonymous);
       }
     }
+  }
+
+  @Test
+  void testRemoveFolderRequiresOwnerOnEveryNote() throws IOException {
+    String note1Id = null;
+    String note2Id = null;
+    try {
+      note1Id = notebook.createNote("/ws_folder/note1", anonymous);
+      note2Id = notebook.createNote("/ws_folder/note2", anonymous);
+      // user1 owns only one of the two notes
+      authorizationService.setOwners(note1Id, new HashSet<>(Arrays.asList("user1")));
+      authorizationService.setOwners(note2Id, new HashSet<>(Arrays.asList("user2")));
+
+      NotebookSocket sock = createWebSocket();
+      notebookServer.onMessage(sock, removeFolderMessage("ws_folder", "user1"));
+
+      // the notes survive and the client is told why
+      assertTrue(notebook.containsNote("/ws_folder/note1"));
+      assertTrue(notebook.containsNote("/ws_folder/note2"));
+      ArgumentCaptor<String> sent = ArgumentCaptor.forClass(String.class);
+      verify(sock, atLeastOnce()).send(sent.capture());
+      assertTrue(sent.getAllValues().stream().anyMatch(m -> m.contains(OP.AUTH_INFO.name())),
+          "Expected an AUTH_INFO message, but got: " + sent.getAllValues());
+
+      // the owner of every note succeeds
+      authorizationService.setOwners(note2Id, new HashSet<>(Arrays.asList("user1")));
+      notebookServer.onMessage(createWebSocket(), removeFolderMessage("ws_folder", "user1"));
+      assertFalse(notebook.containsNote("/ws_folder/note1"));
+      assertFalse(notebook.containsNote("/ws_folder/note2"));
+      note1Id = null;
+      note2Id = null;
+    } finally {
+      if (note1Id != null) {
+        notebook.removeNote(note1Id, anonymous);
+      }
+      if (note2Id != null) {
+        notebook.removeNote(note2Id, anonymous);
+      }
+    }
+  }
+
+  private String removeFolderMessage(String folderPath, String principal) {
+    String ticket = TicketContainer.instance.getTicket(principal,
+        new HashSet<>(Arrays.asList(principal)));
+    Message message = new Message(OP.REMOVE_FOLDER).put("id", folderPath);
+    message.principal = principal;
+    message.ticket = ticket;
+    return message.toJson();
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?

Folder level operations in `NotebookService` ran without any permission check. `renameFolder` and `moveFolderToTrash` carried a `//TODO(zjffdu) folder permission check`, and `removeFolder` and `restoreFolder` had no check at all. A user who could only read one note in a folder was able to rename, trash or permanently delete that whole folder, even though the same user could not touch the note itself.

**Deriving a folder permission.** Zeppelin has no folder level ACL. `AuthorizationService` is keyed by note id only and the word "folder" does not appear in it; a folder is just the in-memory tree `NoteManager` builds out of note paths. So `checkFolderPermission` derives the permission of a folder from the notes it holds, walked recursively, and allows the operation only when the caller holds the required permission on every one of them. No new ACL concept, no storage or migration change.

**Permission levels follow the note level policy they mirror**, so this PR extends an existing rule rather than inventing one:

| Folder operation | Level | Note level counterpart |
| --- | --- | --- |
| `FOLDER_RENAME` | OWNER | `NOTE_RENAME` = OWNER |
| `MOVE_FOLDER_TO_TRASH` | OWNER | `MOVE_NOTE_TO_TRASH` = OWNER |
| `REMOVE_FOLDER` | OWNER | `DEL_NOTE` = OWNER |
| `RESTORE_FOLDER` | **WRITER** | `RESTORE_NOTE` = WRITER |

Restore being lower than trash looks asymmetric, but it is exactly the asymmetry the note level policy already has.

**All-or-nothing.** The check completes before any repository call, so a refused operation leaves the folder exactly as it was instead of half applied. Applying a move or a remove only to the subset the caller owns would leave a partially emptied folder that the caller can neither see nor undo.

**A folder holding no note is allowed.** Removing the last note leaves the folder node in the tree, and there is nothing left to protect. Refusing instead would leave empty folders nobody can ever clean up.

**What the error message reveals.** It names the folder and how many notes blocked the call, but not which ones, since the caller may not be allowed to read them. Those paths go to the server log instead. This is the same split `NotebookRestApi.ownerPermissionError` and `NotebookServer.permissionError` already use, and it matches the existing note level message, which also does not name the note. It is the one place the folder message deliberately differs from the note one: it omits `Allowed users or roles`, because a folder has many notes and the union of their owners would leak exactly what the message is trying to withhold.

`checkPermission` was split into `hasPermission` and `getAllowedEntities` so the folder check can reuse the level dispatch as a plain predicate. The user facing message and behaviour of the note level check are unchanged.

**Relation to earlier work.** PR #4624 (ZEPPELIN-5934, closed by the stale bot after inactivity, never merged) took the same "derive from the notes" approach, and this PR keeps that idea. It differs in four ways: `restoreFolder` is WRITER rather than OWNER so it lines up with `RESTORE_NOTE`; `NoteManager.getFolder` stays private, since the already public `getNoteInfoRecursively` is enough and `NoteManager.Folder` need not reach the service layer; the unrelated `FolderPathAlreadyExistsException` commit is left out; and the tests the reviewer asked for are included.

### Scope

Limited to the four operations that act on one named folder. `EMPTY_TRASH` and `RESTORE_ALL` act on the shared trash as a whole and are untouched, on purpose.

`emptyTrash` does destroy trashed notes without a check, so it can still remove a folder that `removeFolder` now refuses. That gap is not introduced here: `removeNote` already requires OWNER for a single note today, and `emptyTrash` already bypasses it. It belongs to note level enforcement, and deciding who may empty a trash that every user shares is a product question worth its own issue rather than a rider on this fix. Happy to file it as a follow-up.

Two adjacent issues are also left alone: `renameFolder` checks the source folder but not the destination, so renaming onto an existing folder path is still unguarded (ZEPPELIN-5333), and `moveFolderToTrash` detects trash name conflicts with `containsNote` on a folder path, which never matches.

### Known limitation

The check and the operation are not atomic. If another user adds a note to the folder between them, that note is included in the operation without having been checked. Every existing note level `checkPermission` call has the same shape, so closing it would mean introducing locking across the whole permission layer rather than in this path alone.

### What type of PR is it?

Bug Fix

### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-5934

### How should this be tested?

Automated. `mvn test -pl zeppelin-server -Dtest='NotebookServiceTest,NotebookServerTest,NotebookSecurityRestApiTest'`

`NotebookServiceTest`

* `testFolderOperationsRequirePermissionOnEveryNote` — a folder holds two notes, the caller owns one of them, and the blocking note sits in a sub folder so the check is only reached by walking recursively. `renameFolder`, `moveFolderToTrash` and `removeFolder` are all refused with a `ForbiddenException`, both notes are still at their original paths afterwards, and the message names the folder but not the blocking note. The owner of both notes then performs the same operations successfully.
* `testRestoreFolderRequiresWriterPermission` — a reader is refused, a writer succeeds and the note is back at its original path.
* `testRemoveFolderHoldingNoNoteIsAllowed` — pins the empty folder decision.

`NotebookServerTest#testRemoveFolderRequiresOwnerOnEveryNote` covers the real entry point. There is no REST endpoint for folder operations; every caller of these service methods is in `NotebookServer`, so this drives a real `MiniZeppelinServer` with an actual `REMOVE_FOLDER` WebSocket message carrying a `TicketContainer` principal. It asserts the notes survive and the client receives `AUTH_INFO`, then that the same message succeeds once the caller owns everything.

Without the production change, two of the `NotebookServiceTest` cases and the `NotebookServerTest` case fail; the WebSocket one fails on the folder actually having been deleted by a non-owner.

`NotebookSecurityRestApiTest` (a real server with Shiro over HTTP) passes unchanged, covering the `checkPermission` split.

Manual: with two users, give user A owner of a note inside a folder and leave user B as reader only, then have B rename, trash and delete the folder from the notebook list. Each is refused and the folder stays.

### Questions

* Does the license files need to update? No.
* Is there breaking changes for older versions? Behaviour changes on purpose: folder rename, trash, remove and restore now fail for users who lack the permission on every note in the folder, where they previously succeeded. Deployments that relied on the missing check will see refusals. No API, config or storage format change.
* Does this needs documentation? No. It brings folder operations in line with the note permission model the docs already describe.
