### PR TITLE
[ZEPPELIN-3798] Fix wrong link to Dynamic Form docs on Zeppelin Context webpage

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -110,12 +110,12 @@
                 <li><a href="{{BASE_PATH}}/setup/security/http_security_headers.html">HTTP Security Headers</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="title"><span>Notebook Storage</span></li>
-                <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-local-git-repository">Git Storage</a></li>
-                <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-s3">S3 Storage</a></li>
-                <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-azure">Azure Storage</a></li>
-                <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-google-cloud-storage">Google Cloud Storage</a></li>
-                <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-oss">OSS Storage</a></li>
-                <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-mongodb">MongoDB Storage</a></li>
+                <li><a href="{{BASE_PATH}}/setup/storage/notebook_storage.html#Git">Git Storage</a></li>
+                <li><a href="{{BASE_PATH}}/setup/storage/notebook_storage.html#S3">S3 Storage</a></li>
+                <li><a href="{{BASE_PATH}}/setup/storage/notebook_storage.html#Azure">Azure Storage</a></li>
+                <li><a href="{{BASE_PATH}}/setup/storage/notebook_storage.html#GCS">Google Cloud Storage</a></li>
+                <li><a href="{{BASE_PATH}}/setup/storage/notebook_storage.html#OSS">OSS Storage</a></li>
+                <li><a href="{{BASE_PATH}}/setup/storage/notebook_storage.html#MongoDB">MongoDB Storage</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="title"><span>Operation</span></li>
                 <li><a href="{{BASE_PATH}}/setup/operation/configuration.html">Configuration</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,11 +107,11 @@ limitations under the License.
   * [Data Source Authorization](./setup/security/datasource_authorization.html)
   * [HTTP Security Headers](./setup/security/http_security_headers.html)
 * Notebook Storage: a guide about saving notebooks to external storage
-  * [Git Storage](./setup/storage/storage.html#notebook-storage-in-local-git-repository)
-  * [S3 Storage](./setup/storage/storage.html#notebook-storage-in-s3)
-  * [Azure Storage](./setup/storage/storage.html#notebook-storage-in-azure)
-  * [Google Cloud Storage](./setup/storage/storage.html#notebook-storage-in-gcs)
-  * [MongoDB Storage](./setup/storage/storage.html#notebook-storage-in-mongodb)
+  * [Git Storage](./setup/storage/notebook_storage.html#Git)
+  * [S3 Storage](./setup/storage/notebook_storage.html#S3)
+  * [Azure Storage](./setup/storage/notebook_storage.html#Azure)
+  * [Google Cloud Storage](./setup/storage/notebook_storage.html#GCS)
+  * [MongoDB Storage](./setup/storage/notebook_storage.html#MongoDB)
 * Operation 
   * [Configuration](./setup/operation/configuration.html): lists for Apache Zeppelin
   * [Monitoring](./setup/operation/monitoring.html): monitoring instructions for Apache Zeppelin

--- a/docs/pleasecontribute.md
+++ b/docs/pleasecontribute.md
@@ -25,4 +25,4 @@ The content does not exist yet.
 
 We're always welcoming contribution.
 
-If you're interested, please check [How to contribute (website)](./development/howtocontributewebsite.html).
+If you're interested, please check [How to contribute (website)](./development/contribution/how_to_contribute_website.html).

--- a/docs/usage/interpreter/overview.md
+++ b/docs/usage/interpreter/overview.md
@@ -89,7 +89,7 @@ If the context parameter is null, then it is replaced by an empty string. The fo
 Every interpreter belongs to an **Interpreter Group**. Interpreter Groups are units of interpreters that run in one single JVM process and can be started/stopped together.
 By default, every interpreter belongs to a separate group, but the group might contain more interpreters. For example, the Spark interpreter group includes Scala Spark, PySpark, IPySpark and Spark SQL.
 
-Technically, Zeppelin interpreters from the same group run within the same JVM. For more information about this, please consult [the documentation on writing interpreters](../development/writing_zeppelin_interpreter.html).
+Technically, Zeppelin interpreters from the same group run within the same JVM. For more information about this, please consult [the documentation on writing interpreters](../../development/writing_zeppelin_interpreter.html).
 
 Each interpreter belongs to a single group and is registered together. All relevant properties are listed in the interpreter setting as in the below example.
 

--- a/docs/usage/other_features/zeppelin_context.md
+++ b/docs/usage/other_features/zeppelin_context.md
@@ -195,7 +195,7 @@ Currently only [text](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/
 [options](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option), and 
 [checkbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox) are supported.
 
-Dynamic forms are described in detail here: [Dynamic Form](../usage/dynamic_form/intro.html).
+Dynamic forms are described in detail here: [Dynamic Form](../dynamic_form/intro.html).
 
 In sql environment, you can create dynamic form in simple template.
 
@@ -205,7 +205,7 @@ In sql environment, you can create dynamic form in simple template.
 select * from ${table=defaultTableName} where text like '%${search}%'
 ```
 
-To learn more about dynamic form, checkout [Dynamic Form](../usage/dynamic_form/intro.html).
+To learn more about dynamic form, checkout [Dynamic Form](../dynamic_form/intro.html).
 
 
 ## Usage with Embedded Commands


### PR DESCRIPTION
### What is this PR for?
The two "Dynamic Form" links on the Zeppelin Context page point to `../usage/dynamic_form/intro.html`. The page itself is served from `/usage/other_features/`, so that relative path resolves to `/usage/usage/dynamic_form/intro.html` and returns 404. This is still reproducible on the published docs (see the link below). The fix is `../dynamic_form/intro.html`, which is how sibling pages such as `other_features/customizing_homepage.md` link to `../display_system/`.

While I was there I audited every relative `.html` link in `docs/` and in the navigation sidebar and found three more broken targets, fixed in the second commit:

* `index.md` and `_navigation.html` link the Notebook Storage entries to `setup/storage/storage.html`, but the file is `notebook_storage.md`. The fragments were wrong too: the docs are rendered with redcarpet, which does not emit heading ids, so the only usable anchors on that page are its explicit `<a name="...">` tags (`Git`, `S3`, `Azure`, `GCS`, `OSS`, `MongoDB`). This one is visible on every docs page because it is in the sidebar.
* `usage/interpreter/overview.md` links to `../development/writing_zeppelin_interpreter.html`, which resolves to `/usage/development/`. It needs one more level up.
* `pleasecontribute.md` links to `development/howtocontributewebsite.html`, which is now `development/contribution/how_to_contribute_website.html`.

After this change every relative `.html` link in `docs/` and in the navigation sidebar resolves to an existing page. Happy to split the second commit out into its own JIRA if you prefer to keep this PR to the reported issue only.

### What type of PR is it?
Bug Fix / Documentation

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3798

### How should this be tested?
Docs only, no code change. The broken link can be seen on the published docs at https://zeppelin.apache.org/docs/0.12.0/usage/other_features/zeppelin_context.html (the "Dynamic Form" links in the body, not the sidebar one), and the Notebook Storage entries in the left sidebar of any docs page 404 as well.

I verified the fix by resolving every relative link in `docs/` against the file tree and confirming each target file exists, and by checking that the anchors used for `notebook_storage.html` are present in that page.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No