### PR TITLE
[ZEPPELIN-6461] Fix InterruptedException handling in recoverRunningParagraphs

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -207,7 +207,8 @@ public class Notebook {
     try {
       thread.join();
     } catch (InterruptedException e) {
-      e.printStackTrace();
+      LOGGER.warn("Paragraph recovery thread interrupted", e);
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
 In `Notebook.recoverRunningParagraphs()`, the `InterruptedException` caught from `thread.join()` was handled with `e.printStackTrace()`, which bypasses the project's Log4j2 configuration. Additionally, the thread interrupt status was not restored, preventing callers from observing the interruption. This PR replaces `e.printStackTrace()` with SLF4J logging and adds `Thread.currentThread().interrupt()` to restore the interrupt status.


### What type of PR is it?
Bug Fix

### Todos
* [x] Replace `e.printStackTrace()` with `LOGGER.warn()` (SLF4J)
* [x] Restore thread interrupt status with `Thread.currentThread().interrupt()`

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6461

### How should this be tested?
  ```bash
  ./mvnw test -pl zeppelin-server -Dtest=NotebookTest -DfailIfNoTests=false
```

### Questions:
  - Does the license files need to update? No
  - Is there breaking changes for older versions? No
  - Does this needs documentation? No

