### PR TITLE
[ZEPPELIN-6507] Return empty list from FileInterpreter.completion()

### DIFF
--- a/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -167,6 +168,6 @@ public abstract class FileInterpreter extends Interpreter {
   @Override
   public List<InterpreterCompletion> completion(String buf, int cursor,
       InterpreterContext interpreterContext) {
-    return null;
+    return Collections.emptyList();
   }
 }

--- a/file/src/test/java/org/apache/zeppelin/file/FileInterpreterTest.java
+++ b/file/src/test/java/org/apache/zeppelin/file/FileInterpreterTest.java
@@ -19,12 +19,15 @@
 package org.apache.zeppelin.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -177,5 +180,15 @@ class FileInterpreterTest {
     assertTrue(args.flags.contains('a'));
     assertTrue(args.flags.contains('h'));
     assertFalse(args.flags.contains('-'));
+  }
+
+  @Test
+  void testCompletionReturnsEmptyListInsteadOfNull() {
+    TestFileInterpreter interpreter = new TestFileInterpreter(new Properties());
+
+    List<InterpreterCompletion> completions = interpreter.completion("ls", 2, null);
+
+    assertNotNull(completions, "completion() should never return null");
+    assertTrue(completions.isEmpty(), "Default completion() should return an empty list");
   }
 }


### PR DESCRIPTION
### What is this PR for?
`FileInterpreter.completion()` returns `null` rather than an empty list. Per *Effective Java* Item 54, methods that return a collection should never return `null`, since it forces every caller to add a special-case null check.

In practice this base implementation is not reached today: the only concrete subclass, `HDFSFileInterpreter`, overrides `completion()` with a real implementation. However, if a future `FileInterpreter` subclass omits that override, the `null` would propagate through the completion call chain, which does not perform null checks.

This PR changes the base implementation to return `Collections.emptyList()` and adds a unit test that pins the contract.

### What type of PR is it?
Improvement

### Todos
* [x] - Return `Collections.emptyList()` from `FileInterpreter.completion()`
* [x] - Add `testCompletionReturnsEmptyListInsteadOfNull` to `FileInterpreterTest`

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6507

### How should this be tested?
* `mvn test -pl file -Dtest=FileInterpreterTest`
* `TestFileInterpreter`, the test double already present in `FileInterpreterTest`, does not override `completion()`, so the new test exercises the base implementation directly.
* All 5 tests in `FileInterpreterTest` pass locally.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No