### PR TITLE
[ZEPPELIN-6596] Improve editor fallback logging

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -611,7 +611,10 @@ public class InterpreterSettingManager implements NoteEventListener {
       try {
         return interpreterSetting.getDefaultInterpreterInfo().getEditor();
       } catch (Exception e) {
-        LOGGER.warn(e.getMessage());
+        LOGGER.warn(
+            "Failed to resolve editor setting for the default interpreter of note {}; "
+                + "using default editor",
+            noteId, e);
         return DEFAULT_EDITOR;
       }
     } else {
@@ -648,7 +651,9 @@ public class InterpreterSettingManager implements NoteEventListener {
             }
             return interpreterSetting.getDefaultInterpreterInfo().getEditor();
           } catch (Exception e) {
-            LOGGER.warn(e.getMessage());
+            LOGGER.warn(
+                "Failed to resolve editor setting for interpreter group {}; using default editor",
+                intpGroupName, e);
             return DEFAULT_EDITOR;
           }
         }
@@ -660,7 +665,10 @@ public class InterpreterSettingManager implements NoteEventListener {
           InterpreterSetting interpreterSetting = getInterpreterSettingByName(intpGroupName);
           return interpreterSetting.getInterpreterInfo(intpName).getEditor();
         } catch (Exception e) {
-          LOGGER.warn(e.getMessage());
+          LOGGER.warn(
+              "Failed to resolve editor setting for interpreter {} in group {}; "
+                  + "using default editor",
+              intpName, intpGroupName, e);
           return DEFAULT_EDITOR;
         }
       }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
@@ -18,6 +18,10 @@
 
 package org.apache.zeppelin.interpreter;
 
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
@@ -220,6 +224,31 @@ class InterpreterSettingManagerTest extends AbstractInterpreterTest {
   }
 
   @Test
+  void testGetEditorFallbackLogging() {
+    Logger logger = Logger.getLogger(InterpreterSettingManager.class);
+    TestAppender appender = new TestAppender();
+    logger.addAppender(appender);
+
+    try {
+      Map<String, Object> editor =
+          interpreterSettingManager.getEditorSetting("%test.nonexistent", note1Id);
+
+      assertEquals("text", editor.get("language"));
+      assertEquals(false, editor.get("editOnDblClick"));
+
+      LoggingEvent warning = appender.getWarnEvent();
+      assertNotNull(warning);
+      assertNotNull(warning.getRenderedMessage());
+      assertTrue(warning.getRenderedMessage().contains("test"));
+      assertTrue(warning.getRenderedMessage().contains("nonexistent"));
+      assertNotNull(warning.getThrowableInformation());
+      assertNotNull(warning.getThrowableInformation().getThrowable());
+    } finally {
+      logger.removeAppender(appender);
+    }
+  }
+
+  @Test
   void testRestartShared() throws InterpreterException {
     InterpreterSetting interpreterSetting = interpreterSettingManager.getByName("test");
     interpreterSetting.getOption().setPerUser("shared");
@@ -340,6 +369,31 @@ class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     } finally {
       System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_INCLUDES.getVarName());
       System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_EXCLUDES.getVarName());
+    }
+  }
+
+  private static class TestAppender extends AppenderSkeleton {
+    private final List<LoggingEvent> events = new ArrayList<>();
+
+    @Override
+    protected void append(LoggingEvent event) {
+      events.add(event);
+    }
+
+    LoggingEvent getWarnEvent() {
+      return events.stream()
+          .filter(event -> Level.WARN.equals(event.getLevel()))
+          .findFirst()
+          .orElse(null);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean requiresLayout() {
+      return false;
     }
   }
 }


### PR DESCRIPTION
  ## What is this PR for?

  Improve warning logs emitted when `InterpreterSettingManager#getEditorSetting` falls back to the default editor.

  The previous logs only recorded `e.getMessage()`, which could be null and did not preserve the stack trace. The updated logs include the relevant note, interpreter group, or interpreter name together with the throwable.

  The existing `DEFAULT_EDITOR` fallback behavior is unchanged. Paragraph text is not logged because it may contain notebook code or sensitive information.

  ## What type of PR is it?

  Bug Fix

  ## What is the Jira issue?

  https://issues.apache.org/jira/browse/ZEPPELIN-6596

  ## How should this be tested?

  ```bash
  ./mvnw test -pl zeppelin-server \
    -Dtest=InterpreterSettingManagerTest

  Result:

  Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS