### PR TITLE
[ZEPPELIN-6491] Remove Google Analytics from generated version docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,11 +71,26 @@ If you wish to help us and contribute to Zeppelin Documentation, please look at 
     bundle exec jekyll build --safe
     ```
 
- 2. checkout ASF repo
+ 2. verify no analytics scripts in the generated output
+
+    ```
+    (
+      grep -rnE --include='*.html' \
+        "google-analytics\.com|googletagmanager\.com|analytics\.js|ga\.js|UA-[0-9]" \
+        _site/
+      case $? in
+        0) echo "FAIL: analytics found"; exit 1 ;;
+        1) ;;
+        *) echo "ERROR: scan failed"; exit 2 ;;
+      esac
+    )
+    ```
+
+ 3. checkout ASF repo
 
     ```
     svn co https://svn.apache.org/repos/asf/zeppelin asf-zeppelin
     ```
 
- 3. copy `zeppelin/docs/_site` to `asf-zeppelin/site/docs/[VERSION]`
- 4. `svn commit`
+ 4. copy `zeppelin/docs/_site` to `asf-zeppelin/site/docs/[VERSION]`
+ 5. `svn commit`

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -103,12 +103,7 @@ JB :
   # Set 'provider' to false to turn analytics off globally.
   #
   analytics :
-    provider : google_universal
-    google_classic :
-        tracking_id : 'UA-45176241-2'
-    google_universal :
-        tracking_id : 'UA-45176241-5'
-        domain : 'zeppelin.apache.org'
+    provider : false
     getclicky :
       site_id :
     mixpanel :


### PR DESCRIPTION
### What is this PR for?

This PR removes Google Analytics from generated version documentation by disabling the analytics provider in the Jekyll configuration.

Previously, running `bundle exec jekyll build --safe` generated HTML containing Google Analytics scripts because the `google_universal` analytics provider was enabled. This change disables the provider, removes the Zeppelin-specific Google Analytics tracking IDs, and adds a verification step to the documentation deployment process to help ensure future generated version documentation remains compliant with the ASF website privacy policy.

### What type of PR is it?

Bug Fix

### Todos

* [x] Disable the Google Analytics provider in `docs/_config.yml`
* [x] Remove the Zeppelin-specific Google Analytics tracking IDs
* [x] Add a verification step to `docs/README.md`
* [x] Validate that generated HTML contains no Google Analytics references

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-6491

### How should this be tested?

1. Build the documentation.

```bash
cd docs
bundle exec jekyll build --safe
```

2. Verify that no Google Analytics references exist in the generated HTML.

```bash
(
  grep -rnE --include='*.html' \
    "google-analytics\.com|googletagmanager\.com|analytics\.js|ga\.js|UA-[0-9]" \
    _site/
  case $? in
    0) echo "FAIL: analytics found"; exit 1 ;;
    1) echo "PASS: no Google Analytics references found in generated HTML" ;;
    *) echo "ERROR: scan failed"; exit 2 ;;
  esac
)
```

**Validation results**

* ✅ Documentation build completed successfully.

```text
Configuration file: /Users/chaiwonhwang/Projects/zeppelin/docs/_config.yml
Source: /Users/chaiwonhwang/Projects/zeppelin/docs
Destination: /Users/chaiwonhwang/Projects/zeppelin/docs/_site
Generating...
done in 0.602 seconds.
```

* ✅ Generated HTML validation passed.

```text
PASS: no Google Analytics references found in generated HTML
```

* ✅ Spot-checked the generated `index.html` and a nested documentation page.
* ✅ Confirmed that the analytics include renders no Google Analytics script while normal local assets remain intact.

### Screenshots (if appropriate)

N/A

Validation results are included above.

### Questions:

* Does the license files need to update?

No.

* Is there breaking changes for older versions?

No.

This change only affects future generated version documentation. Existing published documentation in ASF SVN is not modified by this PR.

* Does this needs documentation?

Yes.

`docs/README.md` has been updated to document the verification step before deploying generated documentation.

