### PR TITLE
[ZEPPELIN-6586] Make the login page responsive on narrow viewports

### DIFF
--- a/zeppelin-web-angular/e2e/tests/login/login.spec.ts
+++ b/zeppelin-web-angular/e2e/tests/login/login.spec.ts
@@ -11,6 +11,7 @@
  */
 
 import { expect, test } from '@playwright/test';
+import { DarkModePage } from '../../models/dark-mode-page';
 import { LoginPage } from '../../models/login-page';
 import { LoginTestUtil, TestCredentials } from '../../models/login-page.util';
 import { addPageAnnotationBeforeEach, PAGES } from '../../utils';
@@ -127,4 +128,32 @@ test.describe('Login Page', () => {
 
     await loginPage.waitForErrorMessage();
   });
+
+  for (const theme of ['light', 'dark'] as const) {
+    test(`should fit a narrow viewport without horizontal overflow in ${theme} theme`, async ({ page }) => {
+      await test.step(`Given the ${theme} theme is active on a 375x812 viewport`, async () => {
+        const darkModePage = new DarkModePage(page);
+        await darkModePage.setThemeInLocalStorage(theme);
+        await page.setViewportSize({ width: 375, height: 812 });
+        await page.reload();
+        await expect(loginPage.formContainer).toBeVisible();
+      });
+
+      await test.step('Then the document should not overflow horizontally', async () => {
+        const overflow = await page.evaluate(
+          () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+        );
+        expect(overflow).toBe(0);
+      });
+
+      await test.step('Then the login controls should be fully visible and usable', async () => {
+        await expect(loginPage.userNameInput).toBeInViewport({ ratio: 1 });
+        await expect(loginPage.passwordInput).toBeInViewport({ ratio: 1 });
+        await expect(loginPage.loginButton).toBeInViewport({ ratio: 1 });
+
+        await loginPage.userNameInput.fill('narrow-viewport-user');
+        await expect(loginPage.userNameInput).toHaveValue('narrow-viewport-user');
+      });
+    });
+  }
 });

--- a/zeppelin-web-angular/src/app/pages/login/login.component.less
+++ b/zeppelin-web-angular/src/app/pages/login/login.component.less
@@ -32,7 +32,9 @@
     }
 
     .inner {
+      display: flex;
       width: 800px;
+      max-width: calc(100% - 32px);
       height: 300px;
       position: absolute;
       z-index: 1;
@@ -42,25 +44,35 @@
       box-shadow: @box-shadow-base;
 
       .form {
-        width: 500px;
-        position: absolute;
-        left: 0;
-        height: 100%;
+        flex: 1 1 auto;
+        min-width: 0;
         background: @component-background;
         padding: 36px;
       }
 
       .sidebar {
-        width: 300px;
-        position: absolute;
-        right: 0;
-        height: 100%;
+        flex: 0 0 300px;
         background: @primary-color;
         padding: 24px 36px;
         color: @text-color-dark;
 
         h1 {
           color: @heading-color-dark;
+        }
+      }
+
+      @media (max-width: @screen-sm-max) {
+        flex-direction: column;
+        height: auto;
+        max-height: calc(100% - 32px);
+        overflow-y: auto;
+
+        .form {
+          flex: none;
+        }
+
+        .sidebar {
+          flex: none;
         }
       }
     }


### PR DESCRIPTION
### What is this PR for?

The New UI login page centers a fixed 800px panel (500px form + 300px sidebar, absolutely positioned), so at narrow viewports such as 375x812 the panel overflows both sides of the screen: part of the form is unreachable off the left edge and the welcome sidebar is clipped on the right.

This PR lays the panel out with flexbox instead. The desktop two-column presentation is pixel-identical (500px form + 300px sidebar at the same 800px width), while the panel now shrinks with the viewport and stacks the sidebar below the form at `@screen-sm-max` (767px), following the existing theme tokens. On short viewports (e.g. landscape phones) the stacked panel is capped to the viewport height and scrolls internally, so the form always stays reachable. No new dependency is introduced.

Narrow-viewport Playwright coverage is added to the existing login suite for both light and dark themes: it asserts no document-level horizontal overflow at 375px and that the username field, password field, and login button stay fully visible and usable.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Responsive layout for the login panel
* [x] - Playwright coverage for the narrow viewport (light and dark themes)

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6586

### How should this be tested?
* Run the focused login spec: `cd zeppelin-web-angular && npx playwright test tests/login/login.spec.ts --project=chromium` (requires `conf/shiro.ini` so the login page is shown)
* Open `/#/login` at 375x812 and confirm the form is fully visible with no horizontal overflow; repeat in light and dark themes
* Confirm the desktop two-column layout is unchanged at >=832px
* `cd zeppelin-web-angular && npm run lint`

### Screenshots (if appropriate)

| Before (375x812) | After light (375x812) | After dark (375x812) |
|---|---|---|
| <img width="250" alt="before, panel overflows the viewport" src="https://github.com/user-attachments/assets/a0c4b34f-7a00-4eec-a641-c0c544ae9c6e" /> | <img width="250" alt="after, light theme" src="https://github.com/user-attachments/assets/d27defd6-790a-4b58-b163-118da792af69" /> | <img width="250" alt="after, dark theme" src="https://github.com/user-attachments/assets/2ec90a81-5a7a-4234-a455-0a968526001a" /> |

Desktop (1280px) is unchanged:

<img width="600" alt="after, desktop two-column layout unchanged" src="https://github.com/user-attachments/assets/a6a719c3-ee9b-45f7-92f7-4ef49db95515" />

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
