### PR TITLE
[ZEPPELIN-6635] Remove unnecessary git add from lint-staged configuration

### DIFF
--- a/zeppelin-web-angular/package.json
+++ b/zeppelin-web-angular/package.json
@@ -118,12 +118,10 @@
   "lint-staged": {
     "**/*.ts": [
       "cross-env NODE_OPTIONS='--max-old-space-size=8192' eslint --fix",
-      "./node_modules/.bin/prettier --write",
-      "git add"
+      "./node_modules/.bin/prettier --write"
     ],
     "**/*.{js,json,css,html}": [
-      "./node_modules/.bin/prettier --write",
-      "git add"
+      "./node_modules/.bin/prettier --write"
     ]
   }
 }


### PR DESCRIPTION
### What is this PR for?
This PR removes unnecessary `git add` commands from the `lint-staged` configuration in `zeppelin-web-angular/package.json`.

The project currently uses `lint-staged` v15, and lint-staged has automatically re-staged task modifications since v10. Keeping explicit `git add` entries is outdated and produce warnings, so this cleanup leaves the existing ESLint and Prettier tasks unchanged while relying on lint-staged's built-in staging behavior.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6635

### How should this be tested?
  * Run the frontend pre-commit workflow with staged TypeScript/JavaScript/JSON/CSS/HTML changes and confirm `lint-staged` still runs ESLint/Prettier successfully.
  * Confirm no lint-staged warning is emitted for using `git add` in task configuration.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
