### PR TITLE
[ZEPPELIN-6629] Fix anchor links hidden under navbar

### DIFF
--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -11,6 +11,10 @@ body {
   font-size: 15px;
 }
 
+html {
+  scroll-padding-top: 60px;
+}
+
 .jumbotron {
   background-color: #3071a9;
 }

--- a/docs/assets/themes/zeppelin/js/docs.js
+++ b/docs/assets/themes/zeppelin/js/docs.js
@@ -96,15 +96,6 @@ function viewSolution() {
   });
 }
 
-// A script to fix internal hash links because we have an overlapping top bar.
-// Based on https://github.com/twitter/bootstrap/issues/193#issuecomment-2281510
-function maybeScrollToHash() {
-  if (window.location.hash && $(window.location.hash).length) {
-    var newTop = $(window.location.hash).offset().top - 57;
-    $(window).scrollTop(newTop);
-  }
-}
-
 $(function() {
   codeTabs();
   // Display anchor links when hovering over headers. For documentation of the
@@ -113,10 +104,6 @@ $(function() {
     placement: 'left'
   };
   anchors.add();
-
-  $(window).bind('hashchange', function() {
-    maybeScrollToHash();
-  });
 
   $(document).ready(function() {
     $('#toc').toc();
@@ -131,7 +118,4 @@ $(function() {
     }
   });
 
-  // Scroll now too in case we had opened the page on a hash, but wait a bit because some browsers
-  // will try to do *their* initial scroll after running the onReady handler.
-  $(window).load(function() { setTimeout(function() { maybeScrollToHash(); }, 25); });
 });


### PR DESCRIPTION
### What is this PR for?

Anchor links in the documentation can be hidden behind the fixed 60px navbar.

The existing `maybeScrollToHash()` JavaScript workaround uses a hardcoded 57px offset and does not handle explicit named anchors such as `<a name="S3">`.

This PR replaces the JavaScript workaround with `scroll-padding-top: 60px`, allowing native fragment navigation to account for the fixed navbar. It also removes `maybeScrollToHash()` and its related event handlers.

### What type of PR is it?

Bug Fix

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-6629

### How should this be tested?

Run the documentation site locally and verify the following fragments on the Notebook Storage page:

* `#overview`
* `#notebook-storage-in-s3`
* `#S3`

Verify that each target is visible below the fixed navbar.

Also verify the behavior with a mobile-width viewport.

### Screenshots

Before/after screenshots for `#S3`, if appropriate.

### Questions

* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
