### PR TITLE
[ZEPPELIN-6436] Fix stale module names and test commands in embedding search documentation

### DIFF
--- a/docs/embedding-search.md
+++ b/docs/embedding-search.md
@@ -126,13 +126,13 @@ Requires `zeppelin.search.enable = true` (already the default).
 ## Changes
 
 ### New files
-- `zeppelin-zengine/.../search/EmbeddingSearch.java` — Core implementation (~700 lines)
-- `zeppelin-zengine/.../search/EmbeddingSearchTest.java` — 11 tests including semantic validation
+- `zeppelin-server/.../search/EmbeddingSearch.java` — Core implementation (~700 lines)
+- `zeppelin-server/.../search/EmbeddingSearchTest.java` — 11 tests including semantic validation
 - `docs/embedding-search.md` — This document
 
 ### Modified files — Backend
-- `zeppelin-zengine/pom.xml` — Add `onnxruntime` and `djl-tokenizers` dependencies
-- `zeppelin-zengine/.../conf/ZeppelinConfiguration.java` — Add `ZEPPELIN_SEARCH_SEMANTIC_ENABLE`
+- `zeppelin-server/pom.xml` — Add `onnxruntime` and `djl-tokenizers` dependencies
+- `zeppelin-server/.../conf/ZeppelinConfiguration.java` — Add `ZEPPELIN_SEARCH_SEMANTIC_ENABLE`
 - `zeppelin-server/.../server/ZeppelinServer.java` — Wire `EmbeddingSearch` based on config
 - `NOTICE` — Attribution for ONNX Runtime and DJL
 
@@ -201,11 +201,11 @@ Zeppelin uses Lucene 8.7.0. Upgrading to 9.x is a separate, larger effort.
 
 ```bash
 # Run embedding search tests (requires model download, ~86MB first time)
-ZEPPELIN_EMBEDDING_TEST=true mvn test -pl zeppelin-zengine \
+ZEPPELIN_EMBEDDING_TEST=true mvn test -pl zeppelin-server \
   -Dtest=EmbeddingSearchTest
 
 # Run existing Lucene tests (should still pass, no changes)
-mvn test -pl zeppelin-zengine -Dtest=LuceneSearchTest
+mvn test -pl zeppelin-server -Dtest=LuceneSearchTest
 ```
 
 ### Key tests

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/search/EmbeddingSearchTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/search/EmbeddingSearchTest.java
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
  * <p>These tests require the ONNX model to be downloaded, so they are gated behind
  * the {@code ZEPPELIN_EMBEDDING_TEST} environment variable. To run:
  * <pre>
- *   ZEPPELIN_EMBEDDING_TEST=true mvn test -pl zeppelin-zengine \
+ *   ZEPPELIN_EMBEDDING_TEST=true mvn test -pl zeppelin-server \
  *     -Dtest=EmbeddingSearchTest
  * </pre>
  *


### PR DESCRIPTION
### What is this PR for?
`docs/embedding-search.md` still referenced the `zeppelin-zengine` module, which was merged into `zeppelin-server` in ZEPPELIN-6355 before the embedding search feature was added in ZEPPELIN-6411. As a result, the implementation paths and the `mvn test -pl zeppelin-zengine` commands in the doc no longer match the current repository layout and the test commands fail as written. This PR updates the stale references so the documentation is accurate and the test commands actually run.


### What type of PR is it?
Documentation

### Todos
- [x]  Replace `zeppelin-zengine` references with `zeppelin-server` in implementation paths
- [x] Update `mvn test -pl` commands to target `zeppelin-server`
- [x] Verify referenced source/test files exist at the corrected paths

### What is the Jira issue?
[ZEPPELIN-6436](https://issues.apache.org/jira/browse/ZEPPELIN-6436)

### How should this be tested?
Confirm no stale references remain: `rg -n "zeppelin-zengine" docs/embedding-search.md`
<img width="600" height="40" alt="image" src="https://github.com/user-attachments/assets/bbc621ba-dbd8-4e59-b2d7-bde56243219f" />

Optionally 
Confirm the corrected paths exist in the repo:
`zeppelin-server/src/main/java/org/apache/zeppelin/search/EmbeddingSearch.java`
`zeppelin-server/src/test/java/org/apache/zeppelin/search/EmbeddingSearchTest.java`
`zeppelin-server/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java`

Run the corrected commands to confirm they work:
`mvn test -pl zeppelin-server -Dtest=LuceneSearchTest`
`ZEPPELIN_EMBEDDING_TEST=true mvn test -pl zeppelin-server -Dtest=EmbeddingSearchTest`

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? This PR is the documentation fix.