### PR TITLE
[ZEPPELIN-6451] Add default NotebookRepo settings methods to remove duplicated placeholder implementations

### DIFF
--- a/zeppelin-plugins/notebookrepo/azure/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/azure/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -28,9 +28,7 @@ import com.microsoft.azure.storage.file.ListFileItem;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -173,17 +171,6 @@ public class AzureNotebookRepo extends AbstractNotebookRepo {
 
   @Override
   public void close() {
-  }
-
-  @Override
-  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    LOGGER.warn("Method not implemented");
-    return Collections.emptyList();
-  }
-
-  @Override
-  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
-    LOGGER.warn("Method not implemented");
   }
 
 }

--- a/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/FileSystemNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/FileSystemNotebookRepo.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,17 +129,6 @@ public class FileSystemNotebookRepo extends AbstractNotebookRepo {
   @Override
   public void close() {
     LOGGER.warn("close is not implemented for FileSystemNotebookRepo");
-  }
-
-  @Override
-  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    LOGGER.warn("getSettings is not implemented for FileSystemNotebookRepo");
-    return Collections.emptyList();
-  }
-
-  @Override
-  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
-    LOGGER.warn("updateSettings is not implemented for FileSystemNotebookRepo");
   }
 
 }

--- a/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -304,14 +303,4 @@ public class GCSNotebookRepo extends AbstractNotebookRepo {
     //no-op
   }
 
-  @Override
-  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    LOGGER.warn("getSettings is not implemented for GCSNotebookRepo");
-    return Collections.emptyList();
-  }
-
-  @Override
-  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
-    LOGGER.warn("updateSettings is not implemented for GCSNotebookRepo");
-  }
 }

--- a/zeppelin-plugins/notebookrepo/mongo/src/main/java/org/apache/zeppelin/notebook/repo/MongoNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/mongo/src/main/java/org/apache/zeppelin/notebook/repo/MongoNotebookRepo.java
@@ -332,17 +332,6 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
     client.close();
   }
 
-  @Override
-  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    LOGGER.warn("Method not implemented");
-    return Collections.emptyList();
-  }
-
-  @Override
-  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
-    LOGGER.warn("Method not implemented");
-  }
-
   /**
    * create until parent folder if not exists.
    *

--- a/zeppelin-plugins/notebookrepo/oss/src/main/java/org/apache/zeppelin/notebook/repo/OSSNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/oss/src/main/java/org/apache/zeppelin/notebook/repo/OSSNotebookRepo.java
@@ -184,18 +184,6 @@ public class OSSNotebookRepo extends AbstractNotebookRepo
     ossOperator.shutdown();
   }
 
-  @Override
-  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    LOGGER.warn("Method not implemented");
-    return Collections.emptyList();
-  }
-
-  @Override
-  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
-    LOGGER.warn("Method not implemented");
-  }
-
-
   private static String buildRevisionsDirName(String noteId, String notePath) throws IOException {
     if (!notePath.startsWith("/")) {
       throw new IOException("Invalid notePath: " + notePath);

--- a/zeppelin-plugins/notebookrepo/s3/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/s3/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -23,9 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
@@ -323,16 +321,5 @@ public class S3NotebookRepo extends AbstractNotebookRepo {
     if (s3client != null) {
       s3client.shutdown();
     }
-  }
-
-  @Override
-  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    LOGGER.warn("Method not implemented");
-    return Collections.emptyList();
-  }
-
-  @Override
-  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
-    LOGGER.warn("Method not implemented");
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/repo/InMemoryNotebookRepo.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/repo/InMemoryNotebookRepo.java
@@ -25,9 +25,7 @@ import org.apache.zeppelin.notebook.NoteParser;
 import org.apache.zeppelin.user.AuthenticationInfo;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class InMemoryNotebookRepo extends AbstractNotebookRepo {
@@ -104,16 +102,6 @@ public class InMemoryNotebookRepo extends AbstractNotebookRepo {
 
   @Override
   public void close() {
-
-  }
-
-  @Override
-  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
 
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -23,9 +23,11 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteParser;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.user.AuthenticationInfo;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -125,20 +127,33 @@ public interface NotebookRepo extends Closeable {
   /**
    * Get NotebookRepo settings got the given user.
    *
+   * Implementations that don't expose any configurable setting can rely on this default,
+   * which reports that the repo has no settings.
+   *
    * @param subject
    * @return
    */
   @ZeppelinApi
-  List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject);
+  default List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
+    LoggerFactory.getLogger(getClass())
+        .debug("getSettings is not implemented for {}", getClass().getSimpleName());
+    return Collections.emptyList();
+  }
 
   /**
    * update notebook repo settings.
+   *
+   * Implementations that don't expose any configurable setting can rely on this default,
+   * which ignores the update and warns about it.
    *
    * @param settings
    * @param subject
    */
   @ZeppelinApi
-  void updateSettings(Map<String, String> settings, AuthenticationInfo subject);
+  default void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
+    LoggerFactory.getLogger(getClass())
+        .warn("updateSettings is not implemented for {}", getClass().getSimpleName());
+  }
 
   NoteParser getNoteParser();
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -31,7 +31,6 @@ import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
-import org.apache.zeppelin.notebook.repo.NotebookRepoSettingsInfo;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
 import org.apache.zeppelin.notebook.repo.VFSNotebookRepo;
 import org.apache.zeppelin.notebook.scheduler.QuartzSchedulerService;
@@ -61,7 +60,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -191,16 +189,6 @@ class NotebookTest extends AbstractInterpreterTest implements ParagraphJobListen
     }
 
     @Override
-    public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-      return Collections.emptyList();
-    }
-
-    @Override
-    public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
-
-    }
-
-    @Override
     public NoteParser getNoteParser() {
       return null;
     }
@@ -273,16 +261,6 @@ class NotebookTest extends AbstractInterpreterTest implements ParagraphJobListen
 
     @Override
     public void close() {
-
-    }
-
-    @Override
-    public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-      return Collections.emptyList();
-    }
-
-    @Override
-    public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
 
     }
 


### PR DESCRIPTION
### What is this PR for?
Several `NotebookRepo` implementations (S3, GCS, OSS, Azure, Mongo, FileSystem, InMemory) duplicated the same placeholder code for `getSettings` / `updateSettings` — returning an empty list or logging "Method not implemented".

This PR centralizes that placeholder behavior as `default` methods on the `NotebookRepo` interface:
* `getSettings` returns an empty list and logs at DEBUG level (querying settings is a normal read path, so it should not produce warning noise).
* `updateSettings` is a no-op and logs at WARN level (an ignored update attempt is worth surfacing).

All duplicated overrides are removed from the plugin repos, `InMemoryNotebookRepo`, and the test helper repos in `NotebookTest`. Repos with real settings logic (e.g. `VFSNotebookRepo`, `GitNotebookRepo`) keep their own overrides and are unaffected. Since these are `default` interface methods, existing third-party `NotebookRepo` implementations remain source- and binary-compatible.

### What type of PR is it?
Refactoring

### Todos
* [x] - Add default `getSettings` / `updateSettings` implementations to `NotebookRepo`
* [x] - Remove duplicated placeholder overrides from S3 / GCS / OSS / Azure / Mongo / FileSystem / InMemory repos and test helpers

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6451

### How should this be tested?
* Pure refactoring with behavior preserved — the existing `zeppelin-server` test suite covers the affected code paths:
  `./mvnw test -pl zeppelin-server -am`
* CI should pass.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No — `default` methods keep existing implementations compatible; the only visible change is the log level/message of the placeholder behavior.
* Does this needs documentation? No