### PR TITLE
[ZEPPELIN-6563] Collaborative mode can silently desynchronize paragraph text, and a later commit overwrites the server copy

### DIFF
--- a/zeppelin-common/src/main/java/org/apache/zeppelin/common/Message.java
+++ b/zeppelin-common/src/main/java/org/apache/zeppelin/common/Message.java
@@ -206,6 +206,7 @@ public class Message implements JsonSerializable {
     INTERPRETER_INSTALL_RESULT,   // [s-c] Status of an interpreter installation
     COLLABORATIVE_MODE_STATUS,    // [s-c] collaborative mode status
     PATCH_PARAGRAPH,              // [c-s][s-c] patch editor text
+    GET_PARAGRAPH,                // [c-s] resend a single paragraph after a failed patch
     NOTE_RUNNING_STATUS,        // [s-c] sequential run status will be change
     NOTICE                        // [s-c] Notice
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -771,6 +771,23 @@ public class NotebookService {
                               Map<String, Object> config,
                               ServiceContext context,
                               ServiceCallback<Paragraph> callback) throws IOException {
+    updateParagraph(noteId, paragraphId, title, text, params, config, null, context, callback);
+  }
+
+  /**
+   * @param baseChecksum checksum of the text the client believed the server held, or null to skip
+   *                     the check. When it does not match, the client text is stale or diverged,
+   *                     so it is not stored and the server copy is sent back instead.
+   */
+  public void updateParagraph(String noteId,
+                              String paragraphId,
+                              String title,
+                              String text,
+                              Map<String, Object> params,
+                              Map<String, Object> config,
+                              Integer baseChecksum,
+                              ServiceContext context,
+                              ServiceCallback<Paragraph> callback) throws IOException {
     if (!checkPermission(noteId, Permission.WRITER, Message.OP.COMMIT_PARAGRAPH, context,
         callback)) {
       return;
@@ -785,6 +802,11 @@ public class NotebookService {
         Paragraph p = note.getParagraph(paragraphId);
         if (p == null) {
           callback.onFailure(new ParagraphNotFoundException(paragraphId), context);
+          return null;
+        }
+        if (baseChecksum != null && baseChecksum != checksum(p.getText())) {
+          LOGGER.info("Rejecting stale commit of paragraph {} in note {}", paragraphId, noteId);
+          callback.onSuccess(p, context);
           return null;
         }
         // In personalized mode only the note owner may update the master paragraph, so that
@@ -1547,6 +1569,38 @@ public class NotebookService {
     } catch (IOException e) {
       callback.onFailure(new IOException("Fail to patch", e), context);
     }
+  }
+
+  /**
+   * Resend a single paragraph to a client whose patched text diverged, so that the note as a
+   * whole does not have to be reloaded.
+   */
+  public void getParagraph(String noteId, String paragraphId, ServiceContext context,
+                           ServiceCallback<Paragraph> callback) throws IOException {
+    if (!checkPermission(noteId, Permission.READER, Message.OP.GET_PARAGRAPH, context, callback)) {
+      return;
+    }
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
+        Paragraph p = note.getParagraph(paragraphId);
+        if (p == null) {
+          callback.onFailure(new ParagraphNotFoundException(paragraphId), context);
+          return null;
+        }
+        callback.onSuccess(p, context);
+        return null;
+      });
+  }
+
+  /**
+   * Same algorithm as {@link String#hashCode()} so that the client can compute it identically.
+   */
+  static int checksum(String text) {
+    return text == null ? "".hashCode() : text.hashCode();
   }
 
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -482,6 +482,9 @@ public class NotebookServer implements AngularObjectRegistryListener,
         case PATCH_PARAGRAPH:
           patchParagraph(conn, context, receivedMessage);
           break;
+        case GET_PARAGRAPH:
+          getParagraph(conn, context, receivedMessage);
+          break;
         default:
           break;
       }
@@ -1104,8 +1107,11 @@ public class NotebookServer implements AngularObjectRegistryListener,
     String text = (String) fromMessage.get("paragraph");
     Map<String, Object> params = (Map<String, Object>) fromMessage.get("params");
     Map<String, Object> config = (Map<String, Object>) fromMessage.get("config");
+    Integer baseChecksum = fromMessage.get("baseChecksum") == null
+        ? null : ((Number) fromMessage.get("baseChecksum")).intValue();
 
-    getNotebookService().updateParagraph(noteId, paragraphId, title, text, params, config, context,
+    getNotebookService().updateParagraph(noteId, paragraphId, title, text, params, config,
+        baseChecksum, context,
         new WebSocketServiceCallback<Paragraph>(conn) {
           @Override
           public void onSuccess(Paragraph p, ServiceContext context) throws IOException {
@@ -1143,6 +1149,10 @@ public class NotebookServer implements AngularObjectRegistryListener,
     if (patchText == null) {
       return;
     }
+    // checksums of the sender's text before and after the patch, so receivers can tell whether
+    // their own patchApply produced the same text. Absent for clients that do not send them.
+    Object baseChecksum = fromMessage.get("baseChecksum");
+    Object afterChecksum = fromMessage.get("afterChecksum");
 
     getNotebookService().patchParagraph(noteId, paragraphId, patchText, context,
         new WebSocketServiceCallback<String>(conn) {
@@ -1151,8 +1161,36 @@ public class NotebookServer implements AngularObjectRegistryListener,
             super.onSuccess(result, context);
             Message message = new Message(OP.PATCH_PARAGRAPH)
                 .put("patch", result)
-                .put("paragraphId", paragraphId);
+                .put("paragraphId", paragraphId)
+                .put("noteId", noteId2)
+                .put("baseChecksum", baseChecksum)
+                .put("afterChecksum", afterChecksum);
             connectionManager.broadcastExcept(noteId2, message, conn);
+          }
+        });
+  }
+
+  private void getParagraph(NotebookSocket conn,
+                            ServiceContext context,
+                            Message fromMessage) throws IOException {
+    String paragraphId = fromMessage.getType("id", LOGGER);
+    if (paragraphId == null) {
+      return;
+    }
+    String noteId = connectionManager.getAssociatedNoteId(conn);
+    if (noteId == null) {
+      noteId = fromMessage.getType("noteId", LOGGER);
+      if (noteId == null) {
+        return;
+      }
+    }
+
+    getNotebookService().getParagraph(noteId, paragraphId, context,
+        new WebSocketServiceCallback<Paragraph>(conn) {
+          @Override
+          public void onSuccess(Paragraph p, ServiceContext context) throws IOException {
+            super.onSuccess(p, context);
+            conn.send(serializeMessage(new Message(OP.PARAGRAPH).put("paragraph", p)));
           }
         });
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -779,4 +779,39 @@ class NotebookServiceTest {
       assertEquals("Note name shouldn't end with '/'", e.getMessage());
     }
   }
+
+  @Test
+  void testUpdateParagraphChecksIsBasedOnCurrentServerText() throws IOException {
+    String noteId = notebookService.createNote("/note_checksum", "test", true, context, callback);
+    String paragraphId = notebook.processNote(noteId, note -> {
+      Paragraph p = note.getParagraph(0);
+      p.setText("server text");
+      return p.getId();
+    });
+
+    // a commit based on the text the server holds is stored
+    notebookService.updateParagraph(noteId, paragraphId, "title", "agreed text",
+        new HashMap<>(), new HashMap<>(), "server text".hashCode(), context, callback);
+    notebook.processNote(noteId, note -> {
+      assertEquals("agreed text", note.getParagraph(paragraphId).getText());
+      return null;
+    });
+
+    // a commit based on text the server no longer holds is rejected, keeping the server copy
+    notebookService.updateParagraph(noteId, paragraphId, "stale title", "diverged text",
+        new HashMap<>(), new HashMap<>(), "text nobody has".hashCode(), context, callback);
+    notebook.processNote(noteId, note -> {
+      assertEquals("agreed text", note.getParagraph(paragraphId).getText());
+      assertEquals("title", note.getParagraph(paragraphId).getTitle());
+      return null;
+    });
+
+    // clients that send no checksum keep the previous behaviour
+    notebookService.updateParagraph(noteId, paragraphId, "no checksum", "text without checksum",
+        new HashMap<>(), new HashMap<>(), context, callback);
+    notebook.processNote(noteId, note -> {
+      assertEquals("text without checksum", note.getParagraph(paragraphId).getText());
+      return null;
+    });
+  }
 }

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/checksum.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/checksum.ts
@@ -10,6 +10,14 @@
  * limitations under the License.
  */
 
-export * from './checksum';
-export * from './interfaces/public-api';
-export * from './message';
+/**
+ * Same algorithm as java.lang.String#hashCode(), so a checksum computed here matches the one
+ * NotebookService computes for the same text.
+ */
+export function textChecksum(text: string): number {
+  let hash = 0;
+  for (let i = 0; i < text.length; i++) {
+    hash = (Math.imul(31, hash) + text.charCodeAt(i)) | 0;
+  }
+  return hash;
+}

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-data-type-map.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-data-type-map.interface.ts
@@ -73,6 +73,7 @@ import {
   ParagraphRemove,
   ParagraphRemoved,
   ParagraphStatus,
+  GetParagraph,
   ParasInfo,
   PatchParagraphReceived,
   PatchParagraphSend,
@@ -109,7 +110,7 @@ export interface MessageReceiveDataTypeMap {
   [OP.IMPORT_NOTE]: ImportNoteReceived;
   [OP.SAVE_NOTE_FORMS]: SaveNoteFormsSend;
   [OP.PARAGRAPH]: UpdateParagraph;
-  [OP.PATCH_PARAGRAPH]: PatchParagraphSend;
+  [OP.PATCH_PARAGRAPH]: PatchParagraphReceived;
   [OP.PARAGRAPH_REMOVED]: ParagraphRemoved;
   [OP.EDITOR_SETTING]: EditorSettingReceived;
   [OP.PROGRESS]: Progress;
@@ -161,7 +162,8 @@ export interface MessageSendDataTypeMap {
   [OP.PARAGRAPH_CLEAR_ALL_OUTPUT]: ParagraphClearAllOutput;
   [OP.COMPLETION]: Completion;
   [OP.COMMIT_PARAGRAPH]: CommitParagraph;
-  [OP.PATCH_PARAGRAPH]: PatchParagraphReceived;
+  [OP.PATCH_PARAGRAPH]: PatchParagraphSend;
+  [OP.GET_PARAGRAPH]: GetParagraph;
   [OP.IMPORT_NOTE]: ImportNote;
   [OP.CHECKPOINT_NOTE]: CheckpointNote;
   [OP.SET_NOTE_REVISION]: SetNoteRevision;

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
@@ -517,6 +517,7 @@ export enum OP {
    * patch editor text
    */
   PATCH_PARAGRAPH = 'PATCH_PARAGRAPH',
+  GET_PARAGRAPH = 'GET_PARAGRAPH',
 
   /**
    * [s-c]

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-paragraph.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-paragraph.interface.ts
@@ -171,6 +171,8 @@ export interface RunParagraph extends SendParagraph {
 
 export interface CommitParagraph extends SendParagraph {
   noteId: string;
+  // checksum of the text this client believed the server held; absent for older clients
+  baseChecksum?: number;
 }
 
 export interface RunAllParagraphs {
@@ -264,14 +266,26 @@ export interface CompletionReceived {
 }
 
 export interface PatchParagraphReceived {
-  id: string;
+  paragraphId: string;
   noteId: string;
   patch: string;
+  // checksums of the sender's text before and after the patch; absent for older clients
+  baseChecksum?: number;
+  afterChecksum?: number;
+}
+
+export interface GetParagraph {
+  id: string;
+  noteId: string;
 }
 
 export interface PatchParagraphSend {
-  paragraphId: string;
+  id: string;
+  noteId: string;
   patch: string;
+  // checksums of this client's text before and after the patch; let receivers verify the result
+  baseChecksum?: number;
+  afterChecksum?: number;
 }
 
 export interface ParagraphRemoved {

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -445,7 +445,8 @@ export class Message {
     paragraphData: string,
     paragraphConfig: ParagraphConfig,
     paragraphParams: ParagraphConfig,
-    noteId: string
+    noteId: string,
+    baseChecksum?: number
   ): void {
     return this.send<OP.COMMIT_PARAGRAPH>(OP.COMMIT_PARAGRAPH, {
       id: paragraphId,
@@ -453,18 +454,34 @@ export class Message {
       title: paragraphTitle,
       paragraph: paragraphData,
       config: paragraphConfig,
-      params: paragraphParams
+      params: paragraphParams,
+      baseChecksum
     });
   }
 
-  patchParagraph(paragraphId: string, noteId: string, patch: string): void {
+  patchParagraph(
+    paragraphId: string,
+    noteId: string,
+    patch: string,
+    baseChecksum?: number,
+    afterChecksum?: number
+  ): void {
     // javascript add "," if change contains several patches
     // but java library requires patch list without ","
     const normalPatch = patch.replace(/,@@/g, '@@');
     return this.send<OP.PATCH_PARAGRAPH>(OP.PATCH_PARAGRAPH, {
       id: paragraphId,
       noteId,
-      patch: normalPatch
+      patch: normalPatch,
+      baseChecksum,
+      afterChecksum
+    });
+  }
+
+  getParagraph(paragraphId: string, noteId: string): void {
+    return this.send<OP.GET_PARAGRAPH>(OP.GET_PARAGRAPH, {
+      id: paragraphId,
+      noteId
     });
   }
 

--- a/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
+++ b/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
@@ -23,7 +23,8 @@ import {
   ParagraphConfigResults,
   ParagraphEditorSetting,
   ParagraphItem,
-  ParagraphIResultsMsgItem
+  ParagraphIResultsMsgItem,
+  textChecksum
 } from '@zeppelin/sdk';
 
 import * as DiffMatchPatch from 'diff-match-patch';
@@ -159,8 +160,16 @@ export abstract class ParagraphBase extends MessageListenersManager {
       if (!this.paragraph.text) {
         this.paragraph.text = '';
       }
+      // patch_apply never throws: it drops a hunk it cannot place, and fuzzy matching can apply
+      // one at the wrong offset while still reporting success. Comparing against the sender's
+      // checksums is the only way to tell both apart.
+      const startedFromSameText = data.baseChecksum === textChecksum(this.paragraph.text);
       this.paragraph.text = this.diffMatchPatch.patch_apply(patch, this.paragraph.text)[0];
       this.originalText = this.paragraph.text;
+      if (startedFromSameText && data.afterChecksum !== textChecksum(this.paragraph.text)) {
+        // we no longer hold the text the sender produced, so ask for this paragraph again
+        this.messageService.getParagraph(this.paragraph.id, data.noteId);
+      }
       this.cdr.markForCheck();
     }
   }

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph-patch.spec.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph-patch.spec.ts
@@ -13,6 +13,8 @@
 import { diff_match_patch as DiffMatchPatch } from 'diff-match-patch';
 import { describe, expect, it } from 'vitest';
 
+import { textChecksum } from '@zeppelin/sdk';
+
 import { makeParagraphPatch } from './paragraph-patch';
 
 describe('makeParagraphPatch', () => {
@@ -28,5 +30,22 @@ describe('makeParagraphPatch', () => {
 
   it('rejects text that was never set', () => {
     expect(() => makeParagraphPatch(new DiffMatchPatch(), 'abc', undefined)).toThrow('dirtyText is required');
+  });
+
+  it('carries checksums of the text before and after the patch', () => {
+    const { baseChecksum, afterChecksum } = makeParagraphPatch(new DiffMatchPatch(), 'alpha', 'alpha!');
+
+    // a receiver compares these against its own text to tell an applied patch from a dropped or
+    // misapplied one, so they have to describe the sender's text on both sides of the edit
+    expect(baseChecksum).toBe(textChecksum('alpha'));
+    expect(afterChecksum).toBe(textChecksum('alpha!'));
+    expect(baseChecksum).not.toBe(afterChecksum);
+  });
+
+  it('treats missing original text as empty when checksumming', () => {
+    const { baseChecksum } = makeParagraphPatch(new DiffMatchPatch(), undefined, 'alpha');
+
+    // the server checksums "" for a paragraph it has no text for, so the first patch must agree
+    expect(baseChecksum).toBe(textChecksum(''));
   });
 });

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph-patch.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph-patch.ts
@@ -12,21 +12,29 @@
 
 import * as DiffMatchPatch from 'diff-match-patch';
 
+import { textChecksum } from '@zeppelin/sdk';
+
 /**
  * Builds the patch a collaborating client sends after an edit. An empty string is a valid
  * paragraph state, so only text that was never set is rejected.
+ *
+ * The checksums let a receiver tell whether its own patch_apply reached the same text as the
+ * sender: patch_apply drops a hunk it cannot place and can also apply one at the wrong offset
+ * while reporting success, neither of which is visible from the result alone.
  */
 export function makeParagraphPatch(
   diffMatchPatch: DiffMatchPatch,
   originalText: string | undefined,
   dirtyText: string | undefined
-): { patch: string; originalText: string } {
+): { patch: string; originalText: string; baseChecksum: number; afterChecksum: number } {
   if (dirtyText === undefined) {
     throw new Error('dirtyText is required');
   }
   const previousText = originalText ? originalText : '';
   return {
     patch: diffMatchPatch.patch_make(previousText, dirtyText).toString(),
-    originalText: dirtyText
+    originalText: dirtyText,
+    baseChecksum: textChecksum(previousText),
+    afterChecksum: textChecksum(dirtyText)
   };
 }

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
@@ -41,7 +41,8 @@ import {
   Note,
   ParagraphConfigResult,
   ParagraphItem,
-  ParagraphIResultsMsgItem
+  ParagraphIResultsMsgItem,
+  textChecksum
 } from '@zeppelin/sdk';
 import {
   HeliumService,
@@ -198,9 +199,13 @@ export class NotebookParagraphComponent
   }
 
   sendPatch() {
-    const { patch, originalText } = makeParagraphPatch(this.diffMatchPatch, this.originalText, this.dirtyText);
+    const { patch, originalText, baseChecksum, afterChecksum } = makeParagraphPatch(
+      this.diffMatchPatch,
+      this.originalText,
+      this.dirtyText
+    );
     this.originalText = originalText;
-    this.messageService.patchParagraph(this.paragraph.id, this.note.id, patch);
+    this.messageService.patchParagraph(this.paragraph.id, this.note.id, patch, baseChecksum, afterChecksum);
   }
 
   startSaveTimer() {
@@ -518,7 +523,10 @@ export class NotebookParagraphComponent
       config,
       settings: { params }
     } = this.paragraph;
-    this.messageService.commitParagraph(id, title, text, config, params, this.note.id);
+    // in collaborative mode let the server reject this commit when our text is based on a
+    // paragraph state the server no longer holds
+    const baseChecksum = this.collaborativeMode ? textChecksum(this.originalText || '') : undefined;
+    this.messageService.commitParagraph(id, title, text, config, params, this.note.id, baseChecksum);
     this.cdr.markForCheck();
   }
 

--- a/zeppelin-web-angular/src/app/services/message.service.ts
+++ b/zeppelin-web-angular/src/app/services/message.service.ts
@@ -303,13 +303,32 @@ export class MessageService extends Message implements OnDestroy {
     paragraphData: string,
     paragraphConfig: ParagraphConfig,
     paragraphParams: ParagraphConfig,
-    noteId: string
+    noteId: string,
+    baseChecksum?: number
   ): void {
-    super.commitParagraph(paragraphId, paragraphTitle, paragraphData, paragraphConfig, paragraphParams, noteId);
+    super.commitParagraph(
+      paragraphId,
+      paragraphTitle,
+      paragraphData,
+      paragraphConfig,
+      paragraphParams,
+      noteId,
+      baseChecksum
+    );
   }
 
-  patchParagraph(paragraphId: string, noteId: string, patch: string): void {
-    super.patchParagraph(paragraphId, noteId, patch);
+  patchParagraph(
+    paragraphId: string,
+    noteId: string,
+    patch: string,
+    baseChecksum?: number,
+    afterChecksum?: number
+  ): void {
+    super.patchParagraph(paragraphId, noteId, patch, baseChecksum, afterChecksum);
+  }
+
+  getParagraph(paragraphId: string, noteId: string): void {
+    super.getParagraph(paragraphId, noteId);
   }
 
   importNote(note: ImportNote['note']): void {

--- a/zeppelin-web-angular/vitest.shell.config.mts
+++ b/zeppelin-web-angular/vitest.shell.config.mts
@@ -23,6 +23,15 @@ export default defineConfig({
       legacy: true
     }
   },
+  resolve: {
+    alias: {
+      // The @zeppelin/* aliases live in tsconfig.base.json, which vite does not read, and they
+      // point at dist/ rather than the sources. Mapping the SDK to its source lets specs cover
+      // code that imports from it; other aliases are deliberately left out, since resolving them
+      // pulls in the JIT compiler and monaco.
+      '@zeppelin/sdk': new URL('./projects/zeppelin-sdk/src/public-api.ts', import.meta.url).pathname
+    }
+  },
   test: {
     environment: 'jsdom',
     include: ['src/**/*.spec.ts', 'projects/zeppelin-sdk/**/*.spec.ts', 'projects/zeppelin-visualization/**/*.spec.ts'],


### PR DESCRIPTION
### What is this PR for?
In collaborative mode paragraph text is synchronised with diff-match-patch, and both the receiving client (`paragraph-base.ts`) and the server (`NotebookService.java`) use only element `[0]` of `patch_apply`, discarding the per-hunk success array. A patch that cannot be applied does not throw, and it fails in two different shapes:

- **dropped** — with no matching context, `patch_apply` returns the original text with `[false]`, so the sender's edit silently disappears on that client
- **misapplied** — fuzzy matching can place a hunk at the wrong offset and still report `[true]`. If one user changes `bravo` to `bravo!` while another has deleted that line, the second client ends up with `alpha\n!charlie\n` and a success flag

The second shape is why inspecting the success array is not enough, and the ticket already ruled out both that approach and `Match_Threshold = 0`.

A diverged paragraph does not stay local. Focusing and blurring calls `commitParagraph`, which sends the client's whole paragraph, and the server stores it through `p.setText(text)` without comparing it to what it holds, then broadcasts it to every connection. Whichever client commits first makes its own text authoritative for everyone.

This PR keeps the existing patch mechanism and makes divergence detectable instead:

- **Detection** — senders attach checksums of their text before and after the patch. A receiver that started from the same text but did not reach the same result knows it diverged. When the base checksums differ the receiver is simply editing concurrently, so no verdict is made and the current behaviour is kept; this is what keeps ordinary concurrent editing from being flagged. Sending the text itself would defeat the purpose of patching — the two checksums add about 37 bytes to a ~160 byte patch message.
- **Recovery** — a diverged receiver asks for that one paragraph again through a new `GET_PARAGRAPH` message. The ticket rejected refetching the note because it recreates every editor while the user is typing, so recovery is per paragraph. `broadcastParagraph` already sends a single paragraph, but a client had no way to *ask* for one; the response reuses the existing `OP.PARAGRAPH` handler.
- **Containment** — a commit carries the checksum of the text the client believed the server held. When it does not match, the server keeps its own copy and sends it back rather than storing text that may be diverged.

Both fields are optional: clients that do not send them behave exactly as before.

Two things I deliberately left out of scope, and some type-level changes I had to include:

- **The server-side `patchApply(...)[0]` is unchanged.** The server holds a single authoritative copy and applies every patch in order, so it does not diverge the way a client with local edits does, and the commit check backs it up. I can add a warning there in a follow-up if you would prefer it for diagnostics.
- **The classic UI is unchanged.** `zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js` has the same line, but with the new UI as default the classic one is served under `/classic` and has to be opened deliberately. Since the fields are optional it keeps working unchanged, and mixing the two UIs is safe apart from the classic client losing the check. **Would you prefer I cover it here, or file a follow-up?**
- **Two type-level changes came along with this.** `PatchParagraphSend` and `PatchParagraphReceived` were mapped to the opposite directions in `message-data-type-map.interface.ts`, which left the receiving side typed without `noteId` or the new fields, so they are swapped to match what is actually sent. And after rebasing onto the merged ZEPPELIN-6582, the checksums are computed inside its `makeParagraphPatch()` rather than inline in the component; reaching `textChecksum` from that spec needs vitest to resolve `@zeppelin/sdk`, so `vitest.shell.config.mts` maps that one alias to the SDK source. Only the SDK is mapped, since the others pull in the JIT compiler and monaco. Happy to split either out if you would rather review them separately.

Finally, this does not make the sync conflict-free. diff-match-patch locates a hunk by matching surrounding context, so a concurrent edit that removes that context can still make a patch land in the wrong place. Editors like Google Docs avoid this class of bug with Operational Transformation or CRDTs, where each edit carries an explicit position the server transforms against concurrent operations. Replacing Zeppelin's sync engine would be far larger than this ticket, so this PR takes the narrower path the ticket points at: make divergence detectable, and stop one client's diverged text from becoming everyone's.

### What type of PR is it?
Bug Fix

### Todos
* [x] Send before/after checksums with each patch
* [x] Verify the patched result on the receiver and request the paragraph again when it diverged
* [x] Add `GET_PARAGRAPH` so a single paragraph can be resent
* [x] Reject a commit whose base no longer matches the server text
* [x] Add unit tests for the commit check

### What is the Jira issue?
* [ZEPPELIN-6563](https://issues.apache.org/jira/browse/ZEPPELIN-6563)

### How should this be tested?
New test `NotebookServiceTest#testUpdateParagraphChecksIsBasedOnCurrentServerText` covers the commit check: a commit based on the current server text is stored, one based on text the server no longer holds is rejected and leaves the server copy untouched, and a commit without a checksum keeps the previous behaviour.

```
./mvnw -pl zeppelin-server --am test -Dtest=NotebookServiceTest -DfailIfNoTests=false
```

Result: `Tests run: 10, Failures: 0, Errors: 0`. `--am` matters here: this adds `GET_PARAGRAPH` to `Message.OP` in `zeppelin-common`, so building `zeppelin-server` alone compiles the tests against a stale copy and fails on an unrelated symbol. If a local Zeppelin server is running it holds the Lucene index lock and every test errors out in `setUp`, so stop it first or point `ZEPPELIN_SEARCH_INDEX_PATH` at a scratch directory.

The checksum uses the same algorithm as `String.hashCode()` so both sides compute the same value; I verified Java and TypeScript agree on empty strings, newlines, non-ASCII text, emoji (surrogate pairs) and long input.

```
cd zeppelin-web-angular && npm run test:shell
```

Result: `Tests 31 passed (31)`, including `paragraph-patch.spec.ts` covering the checksums the sender attaches.

Manual: open the same note in two browser sessions and edit the same paragraph concurrently, with one session deleting a line while the other edits it. I confirmed the built bundle ships the new fields and that ordinary collaborative sync still works, but I could not reproduce the divergence by hand — on a local server the patch round trip is fast enough that the window never opens. This matches the ticket's note that existing e2e coverage does not exercise failed or misapplied patches, which is why the commit check is covered by unit tests instead. `Rejecting stale commit of paragraph` in the server log marks a refused commit.


### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No — the new fields are optional, and the new op is only sent after a detected divergence
* Does this needs documentation? No
