### PR TITLE
[ZEPPELIN-6482] Guarantee system restoration when execution fails

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -44,6 +44,12 @@
       <version>2.0-M3</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -51,7 +51,10 @@ public class StaticRepl {
     return execute(generatedClassName, code, ToolProvider.getSystemJavaCompiler());
   }
 
-  public static String execute(String generatedClassName, String code, JavaCompiler compiler) throws Exception {
+  public static String execute(
+      String generatedClassName,
+      String code,
+      JavaCompiler compiler) throws Exception {
 
     if (compiler == null) {
       throw new Exception(
@@ -112,7 +115,12 @@ public class StaticRepl {
       System.setErr(newErr);
 
       DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-      CompilationTask task = compiler.getTask(null, null, diagnostics, null, null, compilationUnits);
+      CompilationTask task = compiler.getTask(null,
+          null,
+          diagnostics,
+          null,
+          null,
+          compilationUnits);
 
       // executing the compilation process
       boolean success = task.call();

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -137,30 +137,28 @@ public class StaticRepl {
 
         LOGGER.error("Exception in Interpreter while compilation", baosErr.toString());
         throw new Exception(baosErr.toString());
-      } else {
-        try {
+      }
 
-          // creating new class loader
-          URLClassLoader classLoader = URLClassLoader.newInstance(new URL[]{new File("").toURI()
-              .toURL()});
-          // execute the Main method
-          Class.forName(generatedClassName, true, classLoader)
-              .getDeclaredMethod("main", new Class[]{String[].class})
-              .invoke(null, new Object[]{null});
+      try {
+        // creating new class loader
+        URLClassLoader classLoader = URLClassLoader.newInstance(new URL[]{new File("").toURI()
+            .toURL()});
+        // execute the Main method
+        Class.forName(generatedClassName, true, classLoader)
+            .getDeclaredMethod("main", new Class[]{String[].class})
+            .invoke(null, new Object[]{null});
 
-          System.out.flush();
-          System.err.flush();
+        System.out.flush();
+        System.err.flush();
 
-          return baosOut.toString();
+        return baosOut.toString();
 
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-                | InvocationTargetException e) {
-          LOGGER.error("Exception in Interpreter while execution", e);
-          System.err.println(e);
-          e.printStackTrace(newErr);
-          throw new Exception(baosErr.toString(), e);
-
-        }
+      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+              | InvocationTargetException e) {
+        LOGGER.error("Exception in Interpreter while execution", e);
+        System.err.println(e);
+        e.printStackTrace(newErr);
+        throw new Exception(baosErr.toString(), e);
       }
 
     } finally {

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -48,8 +48,11 @@ public class StaticRepl {
   private static final Logger LOGGER = LoggerFactory.getLogger(StaticRepl.class);
 
   public static String execute(String generatedClassName, String code) throws Exception {
+    return execute(generatedClassName, code, ToolProvider.getSystemJavaCompiler());
+  }
 
-    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+  public static String execute(String generatedClassName, String code, JavaCompiler compiler) throws Exception {
+
     if (compiler == null) {
       throw new Exception(
           "Java compiler not available. Make sure Zeppelin is running on JDK (not JRE).");

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -94,9 +94,6 @@ public class StaticRepl {
     // replace name of class containing Main method with generated name
     code = code.replace(mainClassName, generatedClassName);
 
-    JavaFileObject file = new JavaSourceFromString(generatedClassName, code);
-    Iterable<? extends JavaFileObject> compilationUnits = List.of(file);
-
     ByteArrayOutputStream baosOut = new ByteArrayOutputStream();
     ByteArrayOutputStream baosErr = new ByteArrayOutputStream();
 
@@ -112,55 +109,7 @@ public class StaticRepl {
       System.setOut(newOut);
       System.setErr(newErr);
 
-      DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-      CompilationTask task = compiler.getTask(null,
-          null,
-          diagnostics,
-          null,
-          null,
-          compilationUnits);
-
-      // executing the compilation process
-      boolean success = task.call();
-
-      // if success is false will get error
-      if (!success) {
-        for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
-          if (diagnostic.getLineNumber() == -1) {
-            continue;
-          }
-          System.err.println("line " + diagnostic.getLineNumber() + " : "
-              + diagnostic.getMessage(null));
-        }
-        System.out.flush();
-        System.err.flush();
-
-        LOGGER.error("Exception in Interpreter while compilation", baosErr.toString());
-        throw new Exception(baosErr.toString());
-      }
-
-      try {
-        // creating new class loader
-        URLClassLoader classLoader = URLClassLoader.newInstance(new URL[]{new File("").toURI()
-            .toURL()});
-        // execute the Main method
-        Class.forName(generatedClassName, true, classLoader)
-            .getDeclaredMethod("main", new Class[]{String[].class})
-            .invoke(null, new Object[]{null});
-
-        System.out.flush();
-        System.err.flush();
-
-        return baosOut.toString();
-
-      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-              | InvocationTargetException e) {
-        LOGGER.error("Exception in Interpreter while execution", e);
-        System.err.println(e);
-        e.printStackTrace(newErr);
-        throw new Exception(baosErr.toString(), e);
-      }
-
+      return compileAndRun(generatedClassName, code, compiler, baosOut, baosErr, newErr);
     } finally {
       System.out.flush();
       System.err.flush();
@@ -169,6 +118,67 @@ public class StaticRepl {
       System.setErr(oldErr);
     }
 
+  }
+
+  private static String compileAndRun(
+      String generatedClassName,
+      String code,
+      JavaCompiler compiler,
+      ByteArrayOutputStream baosOut,
+      ByteArrayOutputStream baosErr,
+      PrintStream newErr) throws Exception {
+
+    JavaFileObject file = new JavaSourceFromString(generatedClassName, code);
+    Iterable<? extends JavaFileObject> compilationUnits = List.of(file);
+
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+    CompilationTask task = compiler.getTask(null,
+        null,
+        diagnostics,
+        null,
+        null,
+        compilationUnits);
+
+    // executing the compilation process
+    boolean success = task.call();
+
+    // if success is false will get error
+    if (!success) {
+      for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
+        if (diagnostic.getLineNumber() == -1) {
+          continue;
+        }
+        System.err.println("line " + diagnostic.getLineNumber() + " : "
+            + diagnostic.getMessage(null));
+      }
+      System.out.flush();
+      System.err.flush();
+
+      LOGGER.error("Exception in Interpreter while compilation", baosErr.toString());
+      throw new Exception(baosErr.toString());
+    }
+
+    try {
+      // creating new class loader
+      URLClassLoader classLoader = URLClassLoader.newInstance(new URL[]{new File("").toURI()
+          .toURL()});
+      // execute the Main method
+      Class.forName(generatedClassName, true, classLoader)
+          .getDeclaredMethod("main", new Class[]{String[].class})
+          .invoke(null, new Object[]{null});
+
+      System.out.flush();
+      System.err.flush();
+
+      return baosOut.toString();
+
+    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+            | InvocationTargetException e) {
+      LOGGER.error("Exception in Interpreter while execution", e);
+      System.err.println(e);
+      e.printStackTrace(newErr);
+      throw new Exception(baosErr.toString(), e);
+    }
   }
 
 }

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -162,14 +162,14 @@ public class StaticRepl {
 
         }
       }
-      
+
     } finally {
       System.out.flush();
       System.err.flush();
 
       System.setOut(oldOut);
       System.setErr(oldErr);
-    } 
+    }
 
   }
 

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -102,68 +102,65 @@ public class StaticRepl {
     // Save the old System.out!
     PrintStream oldOut = System.out;
     PrintStream oldErr = System.err;
-    // Tell Java to use your special stream
-    System.setOut(newOut);
-    System.setErr(newErr);
 
-    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-    CompilationTask task = compiler.getTask(null, null, diagnostics, null, null, compilationUnits);
+    try {
+      // Tell Java to use your special stream
+      System.setOut(newOut);
+      System.setErr(newErr);
 
-    // executing the compilation process
-    boolean success = task.call();
+      DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+      CompilationTask task = compiler.getTask(null, null, diagnostics, null, null, compilationUnits);
 
-    // if success is false will get error
-    if (!success) {
-      for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
-        if (diagnostic.getLineNumber() == -1) {
-          continue;
+      // executing the compilation process
+      boolean success = task.call();
+
+      // if success is false will get error
+      if (!success) {
+        for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
+          if (diagnostic.getLineNumber() == -1) {
+            continue;
+          }
+          System.err.println("line " + diagnostic.getLineNumber() + " : "
+              + diagnostic.getMessage(null));
         }
-        System.err.println("line " + diagnostic.getLineNumber() + " : "
-            + diagnostic.getMessage(null));
+        System.out.flush();
+        System.err.flush();
+
+        LOGGER.error("Exception in Interpreter while compilation", baosErr.toString());
+        throw new Exception(baosErr.toString());
+      } else {
+        try {
+
+          // creating new class loader
+          URLClassLoader classLoader = URLClassLoader.newInstance(new URL[]{new File("").toURI()
+              .toURL()});
+          // execute the Main method
+          Class.forName(generatedClassName, true, classLoader)
+              .getDeclaredMethod("main", new Class[]{String[].class})
+              .invoke(null, new Object[]{null});
+
+          System.out.flush();
+          System.err.flush();
+
+          return baosOut.toString();
+
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+                | InvocationTargetException e) {
+          LOGGER.error("Exception in Interpreter while execution", e);
+          System.err.println(e);
+          e.printStackTrace(newErr);
+          throw new Exception(baosErr.toString(), e);
+
+        }
       }
+      
+    } finally {
       System.out.flush();
       System.err.flush();
 
       System.setOut(oldOut);
       System.setErr(oldErr);
-      LOGGER.error("Exception in Interpreter while compilation", baosErr.toString());
-      throw new Exception(baosErr.toString());
-    } else {
-      try {
-
-        // creating new class loader
-        URLClassLoader classLoader = URLClassLoader.newInstance(new URL[]{new File("").toURI()
-            .toURL()});
-        // execute the Main method
-        Class.forName(generatedClassName, true, classLoader)
-            .getDeclaredMethod("main", new Class[]{String[].class})
-            .invoke(null, new Object[]{null});
-
-        System.out.flush();
-        System.err.flush();
-
-        // set the stream to old stream
-        System.setOut(oldOut);
-        System.setErr(oldErr);
-
-        return baosOut.toString();
-
-      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-               | InvocationTargetException e) {
-        LOGGER.error("Exception in Interpreter while execution", e);
-        System.err.println(e);
-        e.printStackTrace(newErr);
-        throw new Exception(baosErr.toString(), e);
-
-      } finally {
-
-        System.out.flush();
-        System.err.flush();
-
-        System.setOut(oldOut);
-        System.setErr(oldErr);
-      }
-    }
+    } 
 
   }
 

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -51,10 +51,8 @@ public class StaticRepl {
     return execute(generatedClassName, code, ToolProvider.getSystemJavaCompiler());
   }
 
-  public static String execute(
-      String generatedClassName,
-      String code,
-      JavaCompiler compiler) throws Exception {
+  static String execute(String generatedClassName, String code, JavaCompiler compiler)
+      throws Exception {
 
     if (compiler == null) {
       throw new Exception(

--- a/java/src/test/java/org/apache/zeppelin/java/StaticReplTest.java
+++ b/java/src/test/java/org/apache/zeppelin/java/StaticReplTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.java;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintStream;
+
+public class StaticReplTest {
+
+    @Test
+    void shouldRestoreSystemStreamsWhenCompilationThrows(){
+      PrintStream originalOut = System.out;
+      PrintStream originalErr = System.err;
+
+      JavaCompiler compiler = mock(JavaCompiler.class);
+      CompilationTask task = mock(CompilationTask.class);
+
+      when(compiler.getTask(any(), any(), any(), any(), any(), any()))
+        .thenReturn(task);
+        
+      when(task.call())
+        .thenThrow(new RuntimeException("Compilation failed unexpectedly"));
+        
+      String code = "public class TestClass {"
+        + " public static void main(String[] args) {}"
+        + "}";
+      
+      try {
+        assertThrows(RuntimeException.class, () -> StaticRepl.execute("TestClass", code, compiler));
+        
+        assertSame(originalOut, System.out);
+        assertSame(originalErr, System.err);
+
+      } finally {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+      }
+        
+    }
+    
+}

--- a/java/src/test/java/org/apache/zeppelin/java/StaticReplTest.java
+++ b/java/src/test/java/org/apache/zeppelin/java/StaticReplTest.java
@@ -33,7 +33,7 @@ import java.io.PrintStream;
 public class StaticReplTest {
 
   @Test
-  void shouldRestoreSystemStreamsWhenCompilationThrows(){
+  void shouldRestoreSystemStreamsWhenCompilationThrows() {
     PrintStream originalOut = System.out;
     PrintStream originalErr = System.err;
 
@@ -42,17 +42,17 @@ public class StaticReplTest {
 
     when(compiler.getTask(any(), any(), any(), any(), any(), any()))
         .thenReturn(task);
-      
+
     when(task.call())
         .thenThrow(new RuntimeException("Compilation failed unexpectedly"));
-      
+
     String code = "public class TestClass {"
         + " public static void main(String[] args) {}"
         + "}";
-    
+
     try {
       assertThrows(RuntimeException.class, () -> StaticRepl.execute("TestClass", code, compiler));
-      
+
       assertSame(originalOut, System.out);
       assertSame(originalErr, System.err);
 
@@ -60,7 +60,7 @@ public class StaticReplTest {
       System.setOut(originalOut);
       System.setErr(originalErr);
     }
-      
+
   }
-    
+
 }

--- a/java/src/test/java/org/apache/zeppelin/java/StaticReplTest.java
+++ b/java/src/test/java/org/apache/zeppelin/java/StaticReplTest.java
@@ -32,35 +32,35 @@ import java.io.PrintStream;
 
 public class StaticReplTest {
 
-    @Test
-    void shouldRestoreSystemStreamsWhenCompilationThrows(){
-      PrintStream originalOut = System.out;
-      PrintStream originalErr = System.err;
+  @Test
+  void shouldRestoreSystemStreamsWhenCompilationThrows(){
+    PrintStream originalOut = System.out;
+    PrintStream originalErr = System.err;
 
-      JavaCompiler compiler = mock(JavaCompiler.class);
-      CompilationTask task = mock(CompilationTask.class);
+    JavaCompiler compiler = mock(JavaCompiler.class);
+    CompilationTask task = mock(CompilationTask.class);
 
-      when(compiler.getTask(any(), any(), any(), any(), any(), any()))
+    when(compiler.getTask(any(), any(), any(), any(), any(), any()))
         .thenReturn(task);
-        
-      when(task.call())
+      
+    when(task.call())
         .thenThrow(new RuntimeException("Compilation failed unexpectedly"));
-        
-      String code = "public class TestClass {"
+      
+    String code = "public class TestClass {"
         + " public static void main(String[] args) {}"
         + "}";
+    
+    try {
+      assertThrows(RuntimeException.class, () -> StaticRepl.execute("TestClass", code, compiler));
       
-      try {
-        assertThrows(RuntimeException.class, () -> StaticRepl.execute("TestClass", code, compiler));
-        
-        assertSame(originalOut, System.out);
-        assertSame(originalErr, System.err);
+      assertSame(originalOut, System.out);
+      assertSame(originalErr, System.err);
 
-      } finally {
-        System.setOut(originalOut);
-        System.setErr(originalErr);
-      }
-        
+    } finally {
+      System.setOut(originalOut);
+      System.setErr(originalErr);
     }
+      
+  }
     
 }


### PR DESCRIPTION
### What is this PR for?
StaticRepl.execute() temporarily redirects System.out and System.err to capture user program output. However, if compiler.getTask(...) or CompilationTask.call() throws an unexpected exception before the existing restoration logic is reached, the global streams can remain redirected.

This PR wraps the redirected-stream section in an outer try/finally so System.out and System.err are always restored to their original streams. A regression test was also added to verify that the streams are restored when CompilationTask.call() throws unexpectedly.


### What type of PR is it?
Bug Fix

### Todos
* [x] - Wrap stream redirection in an outer `try/finally` to guarantee restoration
* [x] - Add a compiler-injection overload for deterministic failure testing
* [x] - Add Mockito as a test dependency to the `java` module
* [x] - Add a regression test for `CompilationTask.call()` failure

### What is the Jira issue?
[[ZEPPELIN-6482]](https://issues.apache.org/jira/browse/ZEPPELIN-6482)

### How should this be tested?
`./mvnw test -pl java`  passes successfully.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
