### PR TITLE
[ZEPPELIN-6640] Theme the React remote from the host instead of the shell's CSS

### DIFF
--- a/zeppelin-web-angular/projects/zeppelin-react/README.md
+++ b/zeppelin-web-angular/projects/zeppelin-react/README.md
@@ -89,6 +89,7 @@ src/
 │   └── PublishedParagraph.tsx   # entry component + mount()
 ├── templates/
 │   └── SingleResultRenderer.tsx # routes result types to renderers
+├── theme/               # host theme detection, antd + chart.js theming
 ├── utils/               # tableUtils, textUtils, exportFile
 └── main.ts              # re-exports for Module Federation
 ```
@@ -109,12 +110,18 @@ export function mount(element: HTMLElement, props: Props): ReactMountHandle;
 
 1. Create a component (e.g. `src/components/<area>/ExampleFeature.tsx`).
 2. Wrap its render tree in `<ReactErrorBoundary onError={props.onError}>`.
-3. Export a `mount(element, props)` function that:
+3. Wrap it in `<ZeppelinThemeProvider>` as well (see `src/theme/`), otherwise
+   antd builds its styles from the default light algorithm and the module only
+   looks right in dark mode while the shell's global `.ant-*` rules happen to
+   cover the components in use. Pass surface specific tokens through its
+   `token` prop, and read `useHostThemeMode()` when you draw outside antd, as
+   a canvas chart does.
+4. Export a `mount(element, props)` function that:
    - Creates a single `Root` via `createRoot(element)`.
    - Calls `root.render(<Wrapped {...props}/>)` on initial mount AND on
      every `update(newProps)` call. React's reconciler preserves state.
    - Returns `{ update, unmount }`. `unmount` calls `root.unmount()`.
-4. Register in `webpack.config.js` under `exposes`:
+5. Register in `webpack.config.js` under `exposes`:
    ```js
    exposes: {
      './PublishedParagraph': './src/pages/PublishedParagraph',
@@ -122,14 +129,14 @@ export function mount(element: HTMLElement, props: Props): ReactMountHandle;
      './ExampleFeature': './src/components/<area>/ExampleFeature'
    }
    ```
-5. Re-export from `main.ts`:
+6. Re-export from `main.ts`:
    ```ts
    export {
      ExampleFeature,
      mount as mountExampleFeature
    } from './components/<area>/ExampleFeature';
    ```
-6. Use from Angular by adding the directive to your template:
+7. Use from Angular by adding the directive to your template:
    ```html
    <div
      zeppelin-react-mount="./ExampleFeature"

--- a/zeppelin-web-angular/projects/zeppelin-react/src/components/visualizations/TableVisualization.tsx
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/components/visualizations/TableVisualization.tsx
@@ -13,6 +13,7 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { Table } from 'antd';
 import { VisualizationControls } from './VisualizationControls';
+import { applyChartTheme, useHostThemeMode } from '@/theme';
 import { parseTableData, exportFile } from '@/utils';
 import type { ParagraphConfigResult, ParagraphIResultsMsgItem, VisualizationMode } from '@zeppelin/sdk';
 import type { Chart, ChartConfiguration } from 'chart.js';
@@ -25,6 +26,7 @@ interface TableVisualizationProps {
 export const TableVisualization = ({ result, config }: TableVisualizationProps) => {
   const [currentMode, setCurrentMode] = useState<VisualizationMode>(config?.graph.mode || 'table');
   const chartRef = useRef<HTMLDivElement>(null);
+  const themeMode = useHostThemeMode();
 
   const tableData = useMemo(() => parseTableData(result.data), [result.data]);
 
@@ -85,6 +87,10 @@ export const TableVisualization = ({ result, config }: TableVisualizationProps) 
       if (cancelled || !container) return;
 
       const ChartConstructor = module.Chart || module.default;
+
+      // Ticks, legend labels and grid lines all resolve from these two
+      // globals, and a canvas is out of reach of the shell's stylesheets.
+      applyChartTheme(ChartConstructor, themeMode);
 
       const canvas = document.createElement('canvas');
       canvas.style.width = '100%';
@@ -222,7 +228,7 @@ export const TableVisualization = ({ result, config }: TableVisualizationProps) 
         container.innerHTML = '';
       }
     };
-  }, [currentMode, tableData]);
+  }, [currentMode, tableData, themeMode]);
 
   return (
     <div>

--- a/zeppelin-web-angular/projects/zeppelin-react/src/pages/PublishedParagraph.tsx
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/pages/PublishedParagraph.tsx
@@ -11,10 +11,12 @@
  */
 
 import { createRoot } from 'react-dom/client';
-import { ConfigProvider } from 'antd';
 import { Empty } from '@/components';
 import { SingleResultRenderer } from '@/templates';
+import { ZeppelinThemeProvider } from '@/theme';
 import type { ParagraphConfigResults, ParagraphIResultsMsgItem } from '@zeppelin/sdk';
+
+const RESULT_FONT_FAMILY = "'Lucida Console', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace";
 
 export interface PublishedParagraphProps {
   paragraphId: string;
@@ -22,19 +24,13 @@ export interface PublishedParagraphProps {
   config?: ParagraphConfigResults;
 }
 
-export const PublishedParagraph = ({ results, config }: PublishedParagraphProps) => {
-  if (!results || results.length === 0) {
-    return <Empty />;
-  }
-
-  return (
-    <ConfigProvider
-      theme={{
-        token: {
-          fontFamily: "'Lucida Console', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace"
-        }
-      }}
-    >
+export const PublishedParagraph = ({ results, config }: PublishedParagraphProps) => (
+  // The empty state is inside the provider too: antd's Empty illustration is
+  // themed, so leaving it outside would leak a light widget into a dark page.
+  <ZeppelinThemeProvider token={{ fontFamily: RESULT_FONT_FAMILY }}>
+    {!results || results.length === 0 ? (
+      <Empty />
+    ) : (
       <div data-testid="react-published-paragraph">
         {results.map((result, index) => (
           <div key={index}>
@@ -42,9 +38,9 @@ export const PublishedParagraph = ({ results, config }: PublishedParagraphProps)
           </div>
         ))}
       </div>
-    </ConfigProvider>
-  );
-};
+    )}
+  </ZeppelinThemeProvider>
+);
 
 export const mount = (element: HTMLElement, props?: PublishedParagraphProps) => {
   if (!element) {

--- a/zeppelin-web-angular/projects/zeppelin-react/src/theme/ZeppelinThemeProvider.spec.tsx
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/theme/ZeppelinThemeProvider.spec.tsx
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import { theme as antdTheme } from 'antd';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useHostThemeMode, ZeppelinThemeProvider } from './ZeppelinThemeProvider';
+import { HostThemeMode } from './hostTheme';
+
+const Probe = () => {
+  const { token } = antdTheme.useToken();
+  return (
+    <>
+      <span data-testid="container-bg">{token.colorBgContainer}</span>
+      <span data-testid="font">{token.fontFamily}</span>
+      <span data-testid="mode">{useHostThemeMode()}</span>
+    </>
+  );
+};
+
+const setHostTheme = (mode: HostThemeMode) => {
+  document.documentElement.setAttribute('data-theme', mode);
+};
+
+describe('ZeppelinThemeProvider', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('builds antd tokens from the dark algorithm when the shell is dark', () => {
+    setHostTheme('dark');
+    render(
+      <ZeppelinThemeProvider>
+        <Probe />
+      </ZeppelinThemeProvider>
+    );
+
+    // Light tokens would put a white container on the shell's dark page; today
+    // that only goes unnoticed because the shell's global .ant-* rules cover it.
+    expect(screen.getByTestId('container-bg').textContent).toBe('#141414');
+    expect(screen.getByTestId('mode').textContent).toBe('dark');
+  });
+
+  it('builds antd tokens from the default algorithm when the shell is light', () => {
+    setHostTheme('light');
+    render(
+      <ZeppelinThemeProvider>
+        <Probe />
+      </ZeppelinThemeProvider>
+    );
+
+    expect(screen.getByTestId('container-bg').textContent).toBe('#ffffff');
+    expect(screen.getByTestId('mode').textContent).toBe('light');
+  });
+
+  it('re-themes in place when the shell toggles the theme', async () => {
+    setHostTheme('light');
+    render(
+      <ZeppelinThemeProvider>
+        <Probe />
+      </ZeppelinThemeProvider>
+    );
+    expect(screen.getByTestId('container-bg').textContent).toBe('#ffffff');
+
+    await act(async () => {
+      setHostTheme('dark');
+    });
+
+    expect(screen.getByTestId('container-bg').textContent).toBe('#141414');
+  });
+
+  it('keeps surface tokens while switching algorithms', () => {
+    setHostTheme('dark');
+    render(
+      <ZeppelinThemeProvider token={{ fontFamily: 'Consolas' }}>
+        <Probe />
+      </ZeppelinThemeProvider>
+    );
+
+    expect(screen.getByTestId('font').textContent).toBe('Consolas');
+    expect(screen.getByTestId('container-bg').textContent).toBe('#141414');
+  });
+});

--- a/zeppelin-web-angular/projects/zeppelin-react/src/theme/ZeppelinThemeProvider.tsx
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/theme/ZeppelinThemeProvider.tsx
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, ReactNode, useContext } from 'react';
+import { ConfigProvider, theme as antdTheme, ThemeConfig } from 'antd';
+import { HostThemeMode, useHostTheme } from './hostTheme';
+
+const HostThemeContext = createContext<HostThemeMode>('light');
+
+/** Resolved host theme for code that draws outside antd, such as canvas charts. */
+export const useHostThemeMode = (): HostThemeMode => useContext(HostThemeContext);
+
+export interface ZeppelinThemeProviderProps {
+  children: ReactNode;
+  /** Extra tokens for a single surface, e.g. a monospace result font. */
+  token?: ThemeConfig['token'];
+}
+
+/**
+ * Every exposed module should render inside this provider. Without it antd
+ * builds its styles from the default (light) algorithm, and the remote looks
+ * dark only for as long as the shell's global `.ant-*` rules happen to cover
+ * the components in use.
+ */
+export const ZeppelinThemeProvider = ({ children, token }: ZeppelinThemeProviderProps) => {
+  const mode = useHostTheme();
+
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: mode === 'dark' ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+        token
+      }}
+    >
+      <HostThemeContext.Provider value={mode}>{children}</HostThemeContext.Provider>
+    </ConfigProvider>
+  );
+};

--- a/zeppelin-web-angular/projects/zeppelin-react/src/theme/chartTheme.spec.ts
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/theme/chartTheme.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyChartTheme, CHART_THEME } from './chartTheme';
+
+// chart.js ships '#666' text and 'rgba(0, 0, 0, 0.1)' grid lines, both of
+// which are meant for a light canvas.
+const chartJsDefaults = () => ({ defaults: { color: '#666', borderColor: 'rgba(0, 0, 0, 0.1)' } });
+
+describe('applyChartTheme', () => {
+  it('replaces the chart.js defaults with the dark palette', () => {
+    const chart = chartJsDefaults();
+
+    applyChartTheme(chart, 'dark');
+
+    expect(chart.defaults.color).toBe(CHART_THEME.dark.text);
+    expect(chart.defaults.borderColor).toBe(CHART_THEME.dark.grid);
+  });
+
+  it('replaces the chart.js defaults with the light palette', () => {
+    const chart = chartJsDefaults();
+
+    applyChartTheme(chart, 'light');
+
+    expect(chart.defaults.color).toBe(CHART_THEME.light.text);
+    expect(chart.defaults.borderColor).toBe(CHART_THEME.light.grid);
+  });
+
+  it('leaves no chart.js default in place for either mode', () => {
+    // The point of the issue: axis labels at '#666' sit at about 3.2:1 against
+    // the shell's dark background, below the 4.5:1 the rest of the UI meets.
+    const untouched = chartJsDefaults().defaults;
+
+    for (const mode of ['light', 'dark'] as const) {
+      const chart = chartJsDefaults();
+      applyChartTheme(chart, mode);
+      expect(chart.defaults.color).not.toBe(untouched.color);
+      expect(chart.defaults.borderColor).not.toBe(untouched.borderColor);
+    }
+  });
+});

--- a/zeppelin-web-angular/projects/zeppelin-react/src/theme/chartTheme.ts
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/theme/chartTheme.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HostThemeMode } from './hostTheme';
+
+/**
+ * Charts are painted on a canvas, so no stylesheet reaches them. chart.js
+ * defaults to '#666' text and 'rgba(0, 0, 0, 0.1)' grid lines, which leaves
+ * axis labels at roughly 3.2:1 against the dark background and the grid
+ * invisible. These values follow antd's secondary text and split tokens.
+ */
+export const CHART_THEME: Record<HostThemeMode, { text: string; grid: string }> = {
+  light: { text: 'rgba(0, 0, 0, 0.65)', grid: 'rgba(0, 0, 0, 0.06)' },
+  dark: { text: 'rgba(255, 255, 255, 0.65)', grid: 'rgba(255, 255, 255, 0.12)' }
+};
+
+/** The two globals chart.js resolves ticks, legend labels and grid lines from. */
+export interface ChartThemeTarget {
+  defaults: {
+    color: unknown;
+    borderColor: unknown;
+  };
+}
+
+export const applyChartTheme = (chart: ChartThemeTarget, mode: HostThemeMode): void => {
+  chart.defaults.color = CHART_THEME[mode].text;
+  chart.defaults.borderColor = CHART_THEME[mode].grid;
+};

--- a/zeppelin-web-angular/projects/zeppelin-react/src/theme/hostTheme.spec.tsx
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/theme/hostTheme.spec.tsx
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HostThemeMode, readHostTheme, useHostTheme } from './hostTheme';
+
+const Probe = () => <span data-testid="mode">{useHostTheme()}</span>;
+
+const setHostTheme = (mode: HostThemeMode) => {
+  document.documentElement.setAttribute('data-theme', mode);
+  document.documentElement.classList.remove('light', 'dark');
+  document.documentElement.classList.add(mode);
+};
+
+const stubMatchMedia = (matches: boolean) => {
+  const listeners = new Set<() => void>();
+  const mql = {
+    matches,
+    addEventListener: (_: string, cb: () => void) => listeners.add(cb),
+    removeEventListener: (_: string, cb: () => void) => listeners.delete(cb)
+  };
+  (window as unknown as { matchMedia?: unknown }).matchMedia = () => mql;
+  return {
+    set: (next: boolean) => {
+      mql.matches = next;
+      listeners.forEach(cb => cb());
+    },
+    listenerCount: () => listeners.size
+  };
+};
+
+describe('readHostTheme', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.classList.remove('light', 'dark');
+    delete (window as unknown as { matchMedia?: unknown }).matchMedia;
+  });
+
+  it('reads the theme the shell writes to the document root', () => {
+    setHostTheme('dark');
+    expect(readHostTheme()).toBe('dark');
+
+    setHostTheme('light');
+    expect(readHostTheme()).toBe('light');
+  });
+
+  it('falls back to the root class when the attribute is missing', () => {
+    document.documentElement.classList.add('dark');
+    expect(readHostTheme()).toBe('dark');
+  });
+
+  it('falls back to the OS preference when the shell declares nothing', () => {
+    stubMatchMedia(true);
+    expect(readHostTheme()).toBe('dark');
+  });
+
+  it('defaults to light when neither the shell nor matchMedia is available', () => {
+    expect(readHostTheme()).toBe('light');
+  });
+});
+
+describe('useHostTheme', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.classList.remove('light', 'dark');
+    delete (window as unknown as { matchMedia?: unknown }).matchMedia;
+  });
+
+  it('starts from the declared theme', () => {
+    setHostTheme('dark');
+    render(<Probe />);
+
+    expect(screen.getByTestId('mode').textContent).toBe('dark');
+  });
+
+  it('follows the shell when the user toggles the theme while mounted', async () => {
+    setHostTheme('light');
+    render(<Probe />);
+    expect(screen.getByTestId('mode').textContent).toBe('light');
+
+    await act(async () => {
+      setHostTheme('dark');
+    });
+
+    expect(screen.getByTestId('mode').textContent).toBe('dark');
+  });
+
+  it('follows the OS only while the shell has declared nothing', () => {
+    const media = stubMatchMedia(false);
+    render(<Probe />);
+    expect(screen.getByTestId('mode').textContent).toBe('light');
+    expect(media.listenerCount()).toBe(1);
+
+    act(() => {
+      media.set(true);
+    });
+
+    expect(screen.getByTestId('mode').textContent).toBe('dark');
+  });
+
+  it('does not subscribe to the OS when the shell declares a theme', () => {
+    const media = stubMatchMedia(true);
+    setHostTheme('light');
+    render(<Probe />);
+
+    // The shell already resolved 'system' for us, so a second source would
+    // let the OS override an explicit light/dark choice.
+    expect(screen.getByTestId('mode').textContent).toBe('light');
+    expect(media.listenerCount()).toBe(0);
+  });
+});

--- a/zeppelin-web-angular/projects/zeppelin-react/src/theme/hostTheme.ts
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/theme/hostTheme.ts
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+export type HostThemeMode = 'light' | 'dark';
+
+/**
+ * The Angular shell's ThemeService resolves 'system' for us and writes the
+ * result to the document root as `data-theme` plus a `dark`/`light` class.
+ * Reading that is what keeps the remote in step with the host without the
+ * host having to thread a prop through every mount point.
+ */
+export const readHostTheme = (): HostThemeMode => {
+  const root = document.documentElement;
+  const declared = root.getAttribute('data-theme');
+  if (declared === 'dark' || declared === 'light') {
+    return declared;
+  }
+  if (root.classList.contains('dark')) {
+    return 'dark';
+  }
+  if (root.classList.contains('light')) {
+    return 'light';
+  }
+
+  // Standalone dev server (port 3001) has no shell, so fall back to the OS
+  // preference the shell would have resolved itself.
+  if (typeof window.matchMedia === 'function') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  return 'light';
+};
+
+const hostDeclaresTheme = (): boolean => {
+  const root = document.documentElement;
+  return root.hasAttribute('data-theme') || root.classList.contains('dark') || root.classList.contains('light');
+};
+
+/** Resolved host theme, kept up to date while mounted. */
+export const useHostTheme = (): HostThemeMode => {
+  const [mode, setMode] = useState<HostThemeMode>(readHostTheme);
+
+  useEffect(() => {
+    // The shell can apply its theme after the remote mounts, so re-read once
+    // the subscription is in place rather than trusting the initial render.
+    setMode(readHostTheme());
+    const sync = () => setMode(readHostTheme());
+
+    const observer = new MutationObserver(sync);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+
+    // Only follow the OS while the shell has not declared a theme; once it
+    // has, its value already accounts for the 'system' setting.
+    let media: MediaQueryList | undefined;
+    if (!hostDeclaresTheme() && typeof window.matchMedia === 'function') {
+      media = window.matchMedia('(prefers-color-scheme: dark)');
+      media.addEventListener('change', sync);
+    }
+
+    return () => {
+      observer.disconnect();
+      media?.removeEventListener('change', sync);
+    };
+  }, []);
+
+  return mode;
+};

--- a/zeppelin-web-angular/projects/zeppelin-react/src/theme/index.ts
+++ b/zeppelin-web-angular/projects/zeppelin-react/src/theme/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type { HostThemeMode } from './hostTheme';
+export { ZeppelinThemeProvider, useHostThemeMode } from './ZeppelinThemeProvider';
+export { applyChartTheme } from './chartTheme';


### PR DESCRIPTION
### What is this PR for?

The React remote never learns which theme the shell is in. `PublishedParagraph` wraps its tree in antd's `ConfigProvider` but only sets `token.fontFamily`, so antd always builds its styles from the default (light) algorithm.

Dark mode still looks correct today, but not for a reason either side declares. `ThemeService` writes `data-theme` and a `dark` class onto the document root, and the shell's global ng-zorro-antd stylesheet targets the same `.ant-*` class names the remote's markup happens to use, so the shell's dark rules land on top of the remote's own light CSS-in-JS. In the published paragraph with `?react=true` in dark mode, `.ant-table` computes to `rgb(31, 31, 31)`. Disable every stylesheet except the remote's own injected `style[data-css-hash]` tags and the same element becomes `rgb(255, 255, 255)` on the dark page.

Anything the shell's CSS cannot reach stays light. The charts in `TableVisualization` are drawn on a canvas, and no chart config sets axis, grid or legend colors, so chart.js v4 defaults apply (`#666` text, `rgba(0, 0, 0, 0.1)` grid). Against the dark page background (`#141414`) the tick and category labels sit at about 3.2:1, below the 4.5:1 WCAG AA threshold for text, and the grid lines are effectively invisible.

This gives the remote the theme as an input instead of letting it inherit one by accident. `src/theme/hostTheme.ts` reads the theme the shell already publishes on the document root and follows it while mounted, `ZeppelinThemeProvider` selects antd's dark or default algorithm from it and exposes the resolved value through context for code that draws outside antd, and `chartTheme.ts` sets the two chart.js globals that ticks, legend labels and grid lines resolve from.

The theme is read from the DOM rather than passed in through `reactProps`. The published paragraph still mounts through its own `window.reactApp` path, so a props based version would have to be wired into that path as well as the directive, and the two host files it would touch are the ones ZEPPELIN-6564 and ZEPPELIN-6565 are currently changing. Reading the attribute the shell already publishes for its own CSS covers both mount paths and needs no host change, and a theme toggle then re-renders the remote without going through change detection. If you would rather keep host state flowing in through props, having the provider take an explicit `theme` prop is a small follow-up.

Matching the shell pixel for pixel is not the goal. antd's dark container token is `#141414` where ng-zorro's is `#1f1f1f`, and where the shell's global rules still win, they win.

### What type of PR is it?

Bug Fix

### Todos

None

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-6640

### How should this be tested?

* New vitest specs under `projects/zeppelin-react/src/theme/`: theme resolution from the document root and its fallbacks, live updates when the shell toggles the theme, antd algorithm selection asserted through `theme.useToken()`, and the chart.js defaults. The project's suite is green at 29 specs. Note that unit tests do not gate CI yet (ZEPPELIN-6566).
* Manual check in both modes on the published paragraph with `?react=true`, on a paragraph with a TABLE result. Switch to Bar Chart in dark mode: the axis labels, legend and grid lines are readable where they were not. The table view and light mode are unchanged.
* To see the cause rather than the symptom, disable the host's stylesheets in devtools. On master the remote's table turns white on the dark page. Here it stays dark, and the rule the remote injects reads `color: rgba(255, 255, 255, 0.85)`.
* A production build of the remote (`npm run build`).

### Screenshots (if appropriate)

before
<img width="900" height="620" alt="1-before-chart-dark" src="https://github.com/user-attachments/assets/4bbe9715-e30f-43fc-b19d-dea71e51d4c8" />

after
<img width="900" height="620" alt="2-after-chart-dark" src="https://github.com/user-attachments/assets/21631d6e-d636-4768-91af-09d2e8347887" />

### Questions:

* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, `projects/zeppelin-react/README.md` gains the provider step in "Adding a new React module"

