### PR TITLE
[ZEPPELIN-6641] Fix stale rationale in the reportError comment

### DIFF
--- a/zeppelin-web-angular/src/app/share/react-mount/react-mount.directive.ts
+++ b/zeppelin-web-angular/src/app/share/react-mount/react-mount.directive.ts
@@ -132,11 +132,10 @@ export class ReactMountDirective implements OnChanges, OnDestroy {
   private reportError(error: unknown): void {
     const onError = this.latestRawProps.onError;
     if (typeof onError === 'function') {
-      // Re-enter the Angular zone so onError handlers can safely mutate
-      // host state and trigger change detection. React lifecycle callbacks
-      // (e.g. error boundaries) run outside the zone because we mounted
-      // there; calling back into the host without ngZone.run would leave
-      // markForCheck() with nothing to flush.
+      // Re-enter the Angular zone before calling back into the host. We mount
+      // the remote outside the zone, so React lifecycle callbacks (e.g. error
+      // boundaries) run outside it as well, and any async work the handler
+      // starts from there (timers, HTTP) would stay untracked by NgZone.
       this.ngZone.run(() => {
         try {
           onError(error);


### PR DESCRIPTION
### What is this PR for?
The `reportError` comment in `ReactMountDirective` claimed that a `markForCheck()` issued from outside the Angular zone has nothing to flush it. Since Angular 18 that is not accurate: hybrid scheduling notifies `ChangeDetectionSchedulerImpl`, and a tick is scheduled for exactly that case (measured at 1 to 4 ms on a running dev server, see the ZEPPELIN-6565 comment).

This states a rationale that does not depend on internal scheduling behavior. Comment only, no behavior change.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6641

### How should this be tested?
Comment-only change, nothing to test.

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
