### PR TITLE
Unify REST and WebSocket authentication through Shiro

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -115,12 +115,16 @@ admin = *
 #
 # IMPORTANT: Order matters: URL path expressions are evaluated against an incoming request
 # in the order they are defined and the FIRST MATCH WINS.
+# The same Shiro filter handles REST requests and the notebook WebSocket handshake. Keep /ws
+# authenticated unless anonymous notebook access is intentional; replace /ws = authc below with
+# /ws = anon to opt out.
 #
 # To allow anonymous access to all but the stated urls,
 # uncomment the line second last line (/** = anon) and comment the last line (/** = authc)
 #
 /api/version = anon
 /api/cluster/address = anon
+/ws = authc
 # Allow all authenticated users to restart interpreters on a notebook page.
 # Comment out the following line if you would like to authorize only admin users to restart interpreters.
 /api/interpreter/setting/restart/** = authc

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -531,8 +531,8 @@
 
 <property>
   <name>zeppelin.server.allowed.origins</name>
-  <value>*</value>
-  <description>Allowed sources for REST and WebSocket requests (i.e. http://onehost:8080,http://otherhost.com). If you leave * you are vulnerable to https://issues.apache.org/jira/browse/ZEPPELIN-173</description>
+  <value></value>
+  <description>Comma-separated exact origins allowed for REST and WebSocket requests (for example, https://zeppelin.example.com). Empty allows only a local origin using the configured server scheme and port. Use * only to explicitly allow every valid origin.</description>
 </property>
 
 <property>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -121,8 +121,8 @@ Sources descending by priority:
   <tr>
     <td><h6 class="properties">ZEPPELIN_ALLOWED_ORIGINS</h6></td>
     <td><h6 class="properties">zeppelin.server.allowed.origins</h6></td>
-    <td>*</td>
-    <td>Enables a way to specify a ',' separated list of allowed origins for REST and websockets. <br /> e.g. http://localhost:8080</td>
+    <td>(empty)</td>
+    <td>Comma-separated exact origins allowed for REST and WebSockets. Empty allows only a local origin using the configured server scheme and port. Use <code>*</code> only to explicitly allow every valid origin.<br />e.g. https://zeppelin.example.com</td>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_CREDENTIALS_PERSIST</h6></td>

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -29,7 +29,7 @@ limitations under the License.
 When you connect to Apache Zeppelin, you will be asked to enter your credentials. Once you logged in, then you have access to all notes including other user's notes.
 
 ## Important Note
-By default, Zeppelin allows anonymous access. It is strongly recommended that you consider setting up Apache Shiro for authentication (as described in this document, see 2 Secure the Websocket channel), or only deploy and use Zeppelin in a secured and trusted environment.
+By default, Zeppelin allows anonymous access. It is strongly recommended that you consider setting up Apache Shiro for authentication (as described in this document, see 2 Apply one URL policy to REST and WebSocket), or only deploy and use Zeppelin in a secured and trusted environment.
 
 ## Security Setup
 You can setup **Zeppelin notebook authentication** in some simple steps.
@@ -44,7 +44,33 @@ cp conf/shiro.ini.template conf/shiro.ini
 
 For the further information about  `shiro.ini` file format, please refer to [Shiro Configuration](http://shiro.apache.org/configuration.html#Configuration-INISections).
 
-### 2. Start Zeppelin
+### 2. Apply one URL policy to REST and WebSocket
+
+When `shiro.ini` is enabled, Zeppelin routes both REST requests under `/api/*` and the
+WebSocket handshake at `/ws` through the same Shiro filter. Rules in `[urls]` are evaluated
+in order, and the first match wins. For example:
+
+```
+[urls]
+/api/version = anon
+/api/admin/** = authc, roles[admin]
+/ws = authc
+/** = authc
+```
+
+Use `anon` for an explicit exclusion from authentication. For example, `/ws = anon` before
+the catch-all rule intentionally enables anonymous WebSocket connections. Requests under
+`/api/*` or `/ws` that do not match any rule are rejected instead of bypassing authentication.
+
+This URL-policy guarantee applies to Zeppelin's standard INI web environment configured by
+`shiro.ini`. A custom Shiro `WebEnvironment` or filter-chain resolver must preserve the same
+first-match behavior and reject unmatched `/api/*` and `/ws` requests. Authenticated WebSocket
+connections also require a Shiro session-backed subject so Zeppelin can revalidate the exact
+session for the lifetime of the connection; stateless subject configurations are not supported
+for authenticated WebSockets. Zeppelin revalidates that session before processing inbound
+messages and before delivering outbound messages.
+
+### 3. Start Zeppelin
 
 ```bash
 bin/zeppelin-daemon.sh start #(or restart)
@@ -52,7 +78,7 @@ bin/zeppelin-daemon.sh start #(or restart)
 
 Then you can browse Zeppelin at [http://localhost:8080](http://localhost:8080).
 
-### 3. Login
+### 4. Login
 Finally, you can login using one of the below **username/password** combinations.
 
 <center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/zeppelin-login.png"></center>

--- a/docs/usage/rest_api/configuration.md
+++ b/docs/usage/rest_api/configuration.md
@@ -82,7 +82,7 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     "zeppelin.notebook.homescreen": "",
     "zeppelin.notebook.storage": "org.apache.zeppelin.notebook.repo.VFSNotebookRepo",
     "zeppelin.interpreter.connect.timeout": "30000",
-    "zeppelin.server.allowed.origins":"*",
+    "zeppelin.server.allowed.origins":"",
     "zeppelin.encoding": "UTF-8"
   }
 }

--- a/docs/usage/zeppelin_sdk/session_api.md
+++ b/docs/usage/zeppelin_sdk/session_api.md
@@ -34,7 +34,8 @@ It is pretty to create a ZSession and its api is very straightforward, we can se
 It is very easy to create a ZSession, you need to provide ClientConfig, interpreter and also you can customize your ZSession by specificy its interpreter properties.
 
 After you can create ZSession, you need to start it before running any code. 
-ZSession's lifecycle  is under your control, you need to call stop method expclitly, otherwise the interpreter processs will keep running.
+ZSession's lifecycle is under your control; call `close()` explicitly, otherwise the
+interpreter process and client transports will keep running.
 
 {% highlight java %}
 ZSession session = null;
@@ -102,7 +103,7 @@ try {
 } finally {
   if (session != null) {
     try {
-      session.stop();
+      session.close();
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -118,6 +119,8 @@ public void start() throws Exception
 public void start(MessageHandler messageHandler) throws Exception
 
 public void stop() throws Exception
+
+public void close() throws Exception
 
 public ExecuteResult execute(String code) throws Exception
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
     <commons.io.version>2.15.1</commons.io.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.cli.version>1.4</commons.cli.version>
-    <shiro.version>2.0.6</shiro.version>
-    <bouncycastle.version>1.82</bouncycastle.version>
+    <shiro.version>2.2.1</shiro.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <maven.version>3.6.3</maven.version>
     <dropwizard.version>4.2.29</dropwizard.version>
     <micrometer.version>1.14.2</micrometer.version>

--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZSession.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZSession.java
@@ -26,6 +26,8 @@ import org.apache.zeppelin.client.websocket.ZeppelinWebSocketClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +38,7 @@ import java.util.stream.Collectors;
  * There's no Zeppelin concept(like note/paragraph) in ZSession.
  *
  */
-public class ZSession {
+public class ZSession implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZSession.class);
 
   private ZeppelinClient zeppelinClient;
@@ -120,14 +122,7 @@ public class ZSession {
     this.sessionInfo = zeppelinClient.getSession(getSessionId());
 
     if (messageHandler != null) {
-      this.webSocketClient = new ZeppelinWebSocketClient(messageHandler);
-      this.webSocketClient.connect(zeppelinClient.getClientConfig().getZeppelinRestUrl()
-              .replace("https", "ws").replace("http", "ws") + "/ws");
-
-      // call GET_NOTE to establish websocket connection between this session and zeppelin-server
-      Message msg = new Message(Message.OP.GET_NOTE);
-      msg.put("id", getNoteId());
-      this.webSocketClient.send(msg);
+      connectWebSocket(messageHandler);
     }
   }
 
@@ -137,11 +132,52 @@ public class ZSession {
    * @throws Exception
    */
   public void stop() throws Exception {
-    if (getSessionId() != null) {
-      zeppelinClient.stopSession(getSessionId());
+    Exception failure = null;
+    try {
+      if (getSessionId() != null) {
+        zeppelinClient.stopSession(getSessionId());
+      }
+    } catch (Exception e) {
+      failure = e;
     }
-    if (webSocketClient != null) {
-      webSocketClient.stop();
+    try {
+      if (webSocketClient != null) {
+        webSocketClient.stop();
+      }
+    } catch (Exception e) {
+      if (failure == null) {
+        failure = e;
+      } else if (failure != e) {
+        failure.addSuppressed(e);
+      }
+    } finally {
+      webSocketClient = null;
+    }
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  /** Stop the remote session and release all client transports. */
+  @Override
+  public void close() throws Exception {
+    Exception failure = null;
+    try {
+      stop();
+    } catch (Exception e) {
+      failure = e;
+    }
+    try {
+      zeppelinClient.close();
+    } catch (RuntimeException e) {
+      if (failure == null) {
+        failure = e;
+      } else if (failure != e) {
+        failure.addSuppressed(e);
+      }
+    }
+    if (failure != null) {
+      throw failure;
     }
   }
 
@@ -168,8 +204,21 @@ public class ZSession {
                                                    String sessionId,
                                                    MessageHandler messageHandler) throws Exception {
     ZSession session = new ZSession(clientConfig, interpreter, sessionId);
-    session.reconnect(messageHandler);
+    session.reconnectOrClose(messageHandler);
     return session;
+  }
+
+  private void reconnectOrClose(MessageHandler messageHandler) throws Exception {
+    try {
+      reconnect(messageHandler);
+    } catch (Exception failure) {
+      try {
+        zeppelinClient.close();
+      } catch (RuntimeException cleanupFailure) {
+        failure.addSuppressed(cleanupFailure);
+      }
+      throw failure;
+    }
   }
 
   private void reconnect(MessageHandler messageHandler) throws Exception {
@@ -179,15 +228,52 @@ public class ZSession {
     }
 
     if (messageHandler != null) {
-      this.webSocketClient = new ZeppelinWebSocketClient(messageHandler);
-      this.webSocketClient.connect(zeppelinClient.getClientConfig().getZeppelinRestUrl()
-              .replace("https", "ws").replace("http", "ws") + "/ws");
+      connectWebSocket(messageHandler);
+    }
+  }
 
-      // call GET_NOTE to establish websocket connection between this session and zeppelin-server
+  private void connectWebSocket(MessageHandler messageHandler) throws Exception {
+    URI webSocketUri = toWebSocketUri(
+        zeppelinClient.getClientConfig().getZeppelinRestUrl());
+    this.webSocketClient = new ZeppelinWebSocketClient(messageHandler);
+    try {
+      this.webSocketClient.connect(
+          webSocketUri.toString(), zeppelinClient.getWebSocketCookieHeader(webSocketUri));
       Message msg = new Message(Message.OP.GET_NOTE);
       msg.put("id", getNoteId());
       this.webSocketClient.send(msg);
+    } catch (Exception failure) {
+      try {
+        this.webSocketClient.stop();
+      } catch (Exception cleanupFailure) {
+        if (failure != cleanupFailure) {
+          failure.addSuppressed(cleanupFailure);
+        }
+      }
+      this.webSocketClient = null;
+      throw failure;
     }
+  }
+
+  static URI toWebSocketUri(String restUrl) throws URISyntaxException {
+    URI restUri = new URI(restUrl);
+    String scheme = restUri.getScheme();
+    if (!("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))
+        || restUri.getHost() == null
+        || restUri.getUserInfo() != null
+        || restUri.getRawQuery() != null
+        || restUri.getRawFragment() != null) {
+      throw new IllegalArgumentException(
+          "Expected an absolute http or https Zeppelin REST URL");
+    }
+
+    String path = restUri.getRawPath();
+    path = path == null ? "" : path;
+    while (path.endsWith("/") && !path.isEmpty()) {
+      path = path.substring(0, path.length() - 1);
+    }
+    String webSocketScheme = "https".equalsIgnoreCase(scheme) ? "wss" : "ws";
+    return new URI(webSocketScheme + "://" + restUri.getRawAuthority() + path + "/ws");
   }
 
   /**

--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZeppelinClient.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZeppelinClient.java
@@ -22,6 +22,7 @@ import kong.unirest.GetRequest;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestInstance;
 import kong.unirest.apache.ApacheClient;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
@@ -33,47 +34,118 @@ import org.apache.zeppelin.common.SessionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import unirest.shaded.org.apache.http.client.HttpClient;
+import unirest.shaded.org.apache.http.cookie.Cookie;
+import unirest.shaded.org.apache.http.cookie.CookieOrigin;
+import unirest.shaded.org.apache.http.cookie.CookiePathComparator;
+import unirest.shaded.org.apache.http.cookie.CookieSpec;
+import unirest.shaded.org.apache.http.impl.client.BasicCookieStore;
+import unirest.shaded.org.apache.http.impl.client.HttpClientBuilder;
 import unirest.shaded.org.apache.http.impl.client.HttpClients;
+import unirest.shaded.org.apache.http.impl.cookie.DefaultCookieSpecProvider;
+import unirest.shaded.org.apache.http.conn.util.PublicSuffixMatcherLoader;
 
 import javax.net.ssl.SSLContext;
+import java.net.URI;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Low level api for interacting with Zeppelin. Underneath, it use the zeppelin rest api.
  * You can use this class to operate Zeppelin note/paragraph,
  * e.g. get/add/delete/update/execute/cancel
+ *
+ * <p>Each instance owns an isolated HTTP transport and cookie store. Use this class in a
+ * try-with-resources statement or call {@link #close()} when it is no longer needed.
  */
-public class ZeppelinClient {
+public class ZeppelinClient implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinClient.class);
 
-  private ClientConfig clientConfig;
+  private final ClientConfig clientConfig;
+  private final UnirestInstance unirest;
+  private final BasicCookieStore cookieStore;
 
   public ZeppelinClient(ClientConfig clientConfig) throws Exception {
     this.clientConfig = clientConfig;
-    Unirest.config().defaultBaseUrl(clientConfig.getZeppelinRestUrl() + "/api");
+    this.unirest = Unirest.spawnInstance();
+    this.cookieStore = new BasicCookieStore();
+    this.unirest.config().defaultBaseUrl(clientConfig.getZeppelinRestUrl() + "/api");
+
+    HttpClientBuilder httpClientBuilder = HttpClients.custom()
+        .useSystemProperties()
+        .setMaxConnTotal(unirest.config().getMaxConnections())
+        .setMaxConnPerRoute(unirest.config().getMaxPerRoutes())
+        .setDefaultCookieStore(cookieStore);
 
     if (clientConfig.isUseKnox()) {
       try {
-        SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, new TrustSelfSignedStrategy() {
-          public boolean isTrusted(X509Certificate[] chain, String authType) {
-            return true;
-          }
-        }).build();
-        HttpClient customHttpClient = HttpClients.custom().setSSLContext(sslContext)
-                .setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
-        Unirest.config().httpClient(ApacheClient.builder(customHttpClient));
+        SSLContext sslContext = new SSLContextBuilder()
+            .loadTrustMaterial(null, new TrustSelfSignedStrategy() {
+              public boolean isTrusted(X509Certificate[] chain, String authType) {
+                return true;
+              }
+            }).build();
+        httpClientBuilder.setSSLContext(sslContext)
+            .setSSLHostnameVerifier(new NoopHostnameVerifier());
       } catch (Exception e) {
+        unirest.close();
         throw new Exception("Fail to setup httpclient of Unirest", e);
       }
     }
+    HttpClient customHttpClient = httpClientBuilder.build();
+    unirest.config().httpClient(ApacheClient.builder(customHttpClient));
   }
 
   public ClientConfig getClientConfig() {
     return clientConfig;
+  }
+
+  String getWebSocketCookieHeader(URI webSocketUri) {
+    String scheme = webSocketUri.getScheme();
+    if (!("ws".equalsIgnoreCase(scheme) || "wss".equalsIgnoreCase(scheme))
+        || webSocketUri.getHost() == null) {
+      throw new IllegalArgumentException("Expected an absolute ws or wss URI");
+    }
+
+    Date now = new Date();
+    cookieStore.clearExpired(now);
+    // Match Apache HttpClient's RequestAddCookies behavior, which uses URI#getPath().
+    String path = webSocketUri.getPath();
+    CookieOrigin origin = new CookieOrigin(
+        webSocketUri.getHost(),
+        effectivePort(webSocketUri),
+        path == null || path.isEmpty() ? "/" : path,
+        "wss".equalsIgnoreCase(scheme));
+    CookieSpec cookieSpec = new DefaultCookieSpecProvider(
+        PublicSuffixMatcherLoader.getDefault()).create(null);
+    List<Cookie> matchingCookies = cookieStore.getCookies().stream()
+        .filter(cookie -> !cookie.isExpired(now) && cookieSpec.match(cookie, origin))
+        .sorted(CookiePathComparator.INSTANCE)
+        .collect(Collectors.toList());
+    if (matchingCookies.isEmpty()) {
+      return "";
+    }
+    String cookieHeader = cookieSpec.formatCookies(matchingCookies).stream()
+        .map(header -> header.getValue())
+        .collect(Collectors.joining("; "));
+    return cookieHeader;
+  }
+
+  private static int effectivePort(URI uri) {
+    if (uri.getPort() >= 0) {
+      return uri.getPort();
+    }
+    return "wss".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+  }
+
+  @Override
+  public void close() {
+    cookieStore.clear();
+    unirest.close();
   }
 
   /**
@@ -119,7 +191,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public String getVersion() throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .get("/version")
             .asJson();
     checkResponse(response);
@@ -137,7 +209,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public SessionInfo newSession(String interpreter) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .post("/session")
             .header("Content-Type", "application/json")
             .queryString("interpreter", interpreter)
@@ -155,7 +227,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public void stopSession(String sessionId) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .delete("/session/{sessionId}")
             .routeParam("sessionId", sessionId)
             .asJson();
@@ -172,7 +244,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public SessionInfo getSession(String sessionId) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .get("/session/{sessionId}")
             .routeParam("sessionId", sessionId)
             .asJson();
@@ -211,7 +283,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public List<SessionInfo> listSessions(String interpreter) throws Exception {
-    GetRequest getRequest = Unirest.get("/session");
+    GetRequest getRequest = unirest.get("/session");
     if (interpreter != null) {
       getRequest.queryString("interpreter", interpreter);
     }
@@ -260,7 +332,7 @@ public class ZeppelinClient {
    */
   public void login(String userName, String password) throws Exception {
     if (clientConfig.isUseKnox()) {
-      HttpResponse<String> response = Unirest.get(clientConfig.getKnoxSSOUrl() +
+      HttpResponse<String> response = unirest.get(clientConfig.getKnoxSSOUrl() +
               "?originalUrl=" + clientConfig.getZeppelinRestUrl())
               .basicAuth(userName, password)
               .asString();
@@ -269,7 +341,7 @@ public class ZeppelinClient {
                 response.getStatus(),
                 response.getStatusText()));
       }
-      response = Unirest.get("/security/ticket")
+      response = unirest.get("/security/ticket")
               .asString();
       if (response.getStatus() != 200) {
         throw new Exception(String.format("Fail to get ticket after Knox SSO, status: %s, statusText: %s",
@@ -277,7 +349,7 @@ public class ZeppelinClient {
                 response.getStatusText()));
       }
     } else {
-      HttpResponse<JsonNode> response = Unirest
+      HttpResponse<JsonNode> response = unirest
               .post("/login")
               .field("userName", userName)
               .field("password", password)
@@ -306,7 +378,7 @@ public class ZeppelinClient {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("notePath", notePath);
     bodyObject.put("defaultInterpreterGroup", defaultInterpreterGroup);
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .post("/notebook")
             .header("Content-Type", "application/json")
             .body(bodyObject.toString())
@@ -325,7 +397,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public void deleteNote(String noteId) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .delete("/notebook/{noteId}")
             .routeParam("noteId", noteId)
             .asJson();
@@ -345,7 +417,7 @@ public class ZeppelinClient {
   public String cloneNote(String noteId, String destPath) throws Exception {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("name", destPath);
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .post("/notebook/{noteId}")
             .routeParam("noteId", noteId)
             .header("Content-Type", "application/json")
@@ -362,7 +434,7 @@ public class ZeppelinClient {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("name", newNotePath);
 
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .put("/notebook/{noteId}/rename")
             .routeParam("noteId", noteId)
             .header("Content-Type", "application/json")
@@ -382,7 +454,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public NoteResult queryNoteResult(String noteId) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .get("/notebook/{noteId}")
             .routeParam("noteId", noteId)
             .asJson();
@@ -399,7 +471,7 @@ public class ZeppelinClient {
   public NoteResult queryNoteResultByPath(String notePath) throws Exception {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("notePath", notePath);
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .post("/notebook/getByPath")
             .header("Content-Type", "application/json")
             .body(bodyObject)
@@ -494,7 +566,7 @@ public class ZeppelinClient {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("params", parameters);
     // run note in non-blocking and isolated way.
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .post("/notebook/job/{noteId}")
             .routeParam("noteId", noteId)
             .queryString("blocking", "false")
@@ -515,7 +587,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public void cancelNote(String noteId) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .delete("/notebook/job/{noteId}")
             .routeParam("noteId", noteId)
             .asJson();
@@ -534,7 +606,7 @@ public class ZeppelinClient {
    */
   public String importNote(String notePath, String noteContent) throws Exception {
     JSONObject bodyObject = new JSONObject(noteContent);
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .post("/notebook/import")
             .queryString("notePath", notePath)
             .header("Content-Type", "application/json")
@@ -597,7 +669,7 @@ public class ZeppelinClient {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("title", title);
     bodyObject.put("text", text);
-    HttpResponse<JsonNode> response = Unirest.post("/notebook/{noteId}/paragraph")
+    HttpResponse<JsonNode> response = unirest.post("/notebook/{noteId}/paragraph")
             .routeParam("noteId", noteId)
             .header("Content-Type", "application/json")
             .body(bodyObject.toString())
@@ -622,7 +694,7 @@ public class ZeppelinClient {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("title", title);
     bodyObject.put("text", text);
-    HttpResponse<JsonNode> response = Unirest.put("/notebook/{noteId}/paragraph/{paragraphId}")
+    HttpResponse<JsonNode> response = unirest.put("/notebook/{noteId}/paragraph/{paragraphId}")
             .routeParam("noteId", noteId)
             .routeParam("paragraphId", paragraphId)
             .header("Content-Type", "application/json")
@@ -712,7 +784,7 @@ public class ZeppelinClient {
                                          Map<String, String> parameters) throws Exception {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("params", parameters);
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .post("/notebook/job/{noteId}/{paragraphId}")
             .routeParam("noteId", noteId)
             .routeParam("paragraphId", paragraphId)
@@ -780,7 +852,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public String nextSessionParagraph(String noteId, int maxParagraph) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .post("/notebook/{noteId}/paragraph/next")
             .routeParam("noteId", noteId)
             .header("Content-Type", "application/json")
@@ -801,7 +873,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public void cancelParagraph(String noteId, String paragraphId) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .delete("/notebook/job/{noteId}/{paragraphId}")
             .routeParam("noteId", noteId)
             .routeParam("paragraphId", paragraphId)
@@ -820,7 +892,7 @@ public class ZeppelinClient {
    * @throws Exception
    */
   public ParagraphResult queryParagraphResult(String noteId, String paragraphId) throws Exception {
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .get("/notebook/{noteId}/paragraph/{paragraphId}")
             .routeParam("noteId", noteId)
             .routeParam("paragraphId", paragraphId)
@@ -900,7 +972,7 @@ public class ZeppelinClient {
   public void stopInterpreter(String noteId, String interpreter) throws Exception {
     JSONObject bodyObject = new JSONObject();
     bodyObject.put("noteId", noteId);
-    HttpResponse<JsonNode> response = Unirest
+    HttpResponse<JsonNode> response = unirest
             .put("/interpreter/setting/restart/{interpreter}")
             .routeParam("interpreter", interpreter)
             .header("Content-Type", "application/json")

--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/websocket/ZeppelinWebSocketClient.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/websocket/ZeppelinWebSocketClient.java
@@ -61,13 +61,16 @@ public class ZeppelinWebSocketClient {
   }
 
   public void connect(String url) throws Exception {
+    connect(url, "");
+  }
+
+  public void connect(String url, String cookieHeader) throws Exception {
+    URI webSocketUri = new URI(url);
+    ClientUpgradeRequest request = createUpgradeRequest(webSocketUri, cookieHeader);
     this.wsClient = new WebSocketClient();
-    wsClient.start();
-    URI echoUri = new URI(url);
-    ClientUpgradeRequest request = new ClientUpgradeRequest();
-    request.setHeader("Origin", "*");
-    CompletableFuture<Session> future = wsClient.connect(this, echoUri, request);
     try {
+      wsClient.start();
+      CompletableFuture<Session> future = wsClient.connect(this, webSocketUri, request);
       future.get(DEFAULT_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
       stopQuietly();
@@ -77,8 +80,38 @@ public class ZeppelinWebSocketClient {
       stopQuietly();
       throw new IOException("Failed to establish websocket connection to " + url,
               e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      stopQuietly();
+      throw e;
+    } catch (Exception e) {
+      stopQuietly();
+      throw e;
     }
     LOGGER.info("WebSocket connect established");
+  }
+
+  static ClientUpgradeRequest createUpgradeRequest(
+      URI webSocketUri, String cookieHeader) throws Exception {
+    String scheme = webSocketUri.getScheme();
+    if (!("ws".equalsIgnoreCase(scheme) || "wss".equalsIgnoreCase(scheme))
+        || webSocketUri.getHost() == null
+        || webSocketUri.getUserInfo() != null) {
+      throw new IllegalArgumentException("Expected an absolute ws or wss URI without credentials");
+    }
+
+    ClientUpgradeRequest request = new ClientUpgradeRequest();
+    if (cookieHeader != null && !cookieHeader.trim().isEmpty()) {
+      request.setHeader("Cookie", cookieHeader);
+    }
+    String httpScheme = "wss".equalsIgnoreCase(scheme) ? "https" : "http";
+    int port = webSocketUri.getPort();
+    int originPort = ("http".equals(httpScheme) && port == 80)
+        || ("https".equals(httpScheme) && port == 443) ? -1 : port;
+    URI origin = new URI(
+        httpScheme, null, webSocketUri.getHost(), originPort, null, null, null);
+    request.setHeader("Origin", origin.toASCIIString());
+    return request;
   }
 
   public void addStatementMessageHandler(String statementId,

--- a/zeppelin-client/src/test/java/org/apache/zeppelin/client/ZSessionTest.java
+++ b/zeppelin-client/src/test/java/org/apache/zeppelin/client/ZSessionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ZSessionTest {
+
+  @Test
+  void convertsHttpRootUrlToWebSocketUrl() throws Exception {
+    assertEquals(
+        "ws://localhost:8080/ws",
+        ZSession.toWebSocketUri("http://localhost:8080").toString());
+  }
+
+  @Test
+  void preservesHttpsGatewayContextPath() throws Exception {
+    assertEquals(
+        "wss://zeppelin.example/gateway/default/zeppelin/ws",
+        ZSession.toWebSocketUri(
+            "https://zeppelin.example/gateway/default/zeppelin///").toString());
+  }
+
+  @Test
+  void preservesEncodedContextPath() throws Exception {
+    assertEquals(
+        "wss://zeppelin.example/gateway%2Fzeppelin/ws",
+        ZSession.toWebSocketUri(
+            "https://zeppelin.example/gateway%2Fzeppelin").toString());
+  }
+
+  @Test
+  void rejectsUnsupportedRestScheme() {
+    assertThrows(IllegalArgumentException.class,
+        () -> ZSession.toWebSocketUri("ftp://zeppelin.example"));
+  }
+}

--- a/zeppelin-client/src/test/java/org/apache/zeppelin/client/ZeppelinClientTest.java
+++ b/zeppelin-client/src/test/java/org/apache/zeppelin/client/ZeppelinClientTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Test;
+
+class ZeppelinClientTest {
+
+  @Test
+  void clientsKeepRestAndWebSocketCookiesIsolatedAndScoped() throws Exception {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/api/login", ZeppelinClientTest::login);
+    server.createContext("/api/version", ZeppelinClientTest::version);
+    server.start();
+    int port = server.getAddress().getPort();
+    String baseUrl = "http://localhost:" + port;
+
+    try (ZeppelinClient first = new ZeppelinClient(new ClientConfig(baseUrl));
+         ZeppelinClient second = new ZeppelinClient(new ClientConfig(baseUrl))) {
+      first.login("user1", "password");
+      second.login("user2", "password");
+
+      assertEquals("user1", first.getVersion());
+      assertEquals("user2", second.getVersion());
+
+      URI wsUri = new URI("ws://localhost:" + port + "/ws");
+      String firstCookies = first.getWebSocketCookieHeader(wsUri);
+      String secondCookies = second.getWebSocketCookieHeader(wsUri);
+      assertTrue(firstCookies.contains("JSESSIONID=user1"));
+      assertTrue(secondCookies.contains("JSESSIONID=user2"));
+      assertTrue(firstCookies.contains("WS_ONLY=ws"));
+      assertFalse(firstCookies.contains("API_ONLY"));
+      assertFalse(firstCookies.contains("SECURE_ONLY"));
+
+      String encodedPathCookies = first.getWebSocketCookieHeader(
+          new URI("ws://localhost:" + port + "/gateway%2Fzeppelin/ws"));
+      assertTrue(encodedPathCookies.contains("ENCODED_CONTEXT=encoded"));
+
+      String secureCookies = first.getWebSocketCookieHeader(
+          new URI("wss://localhost:" + port + "/ws"));
+      assertTrue(secureCookies.contains("SECURE_ONLY=secure"));
+      assertEquals("", first.getWebSocketCookieHeader(
+          new URI("ws://127.0.0.1:" + port + "/ws")));
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  private static void login(HttpExchange exchange) throws IOException {
+    String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    String user = body.contains("userName=user2") ? "user2" : "user1";
+    exchange.getResponseHeaders().add("Set-Cookie", "JSESSIONID=" + user + "; Path=/");
+    exchange.getResponseHeaders().add("Set-Cookie", "WS_ONLY=ws; Path=/ws");
+    exchange.getResponseHeaders().add("Set-Cookie", "API_ONLY=api; Path=/api");
+    exchange.getResponseHeaders().add("Set-Cookie", "SECURE_ONLY=secure; Path=/; Secure");
+    exchange.getResponseHeaders().add(
+        "Set-Cookie", "ENCODED_CONTEXT=encoded; Path=/gateway/zeppelin");
+    respond(exchange, "{\"status\":\"OK\"}");
+  }
+
+  private static void version(HttpExchange exchange) throws IOException {
+    String cookie = exchange.getRequestHeaders().getFirst("Cookie");
+    String user = cookie != null && cookie.contains("JSESSIONID=user2") ? "user2" : "user1";
+    respond(exchange,
+        "{\"status\":\"OK\",\"message\":\"\",\"body\":{\"version\":\""
+            + user + "\"}}");
+  }
+
+  private static void respond(HttpExchange exchange, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json");
+    exchange.sendResponseHeaders(200, bytes.length);
+    exchange.getResponseBody().write(bytes);
+    exchange.close();
+  }
+}

--- a/zeppelin-client/src/test/java/org/apache/zeppelin/client/websocket/ZeppelinWebSocketClientTest.java
+++ b/zeppelin-client/src/test/java/org/apache/zeppelin/client/websocket/ZeppelinWebSocketClientTest.java
@@ -17,14 +17,36 @@
 
 package org.apache.zeppelin.client.websocket;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+import java.net.URI;
 import org.junit.jupiter.api.Test;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 
 import java.time.Duration;
 
 class ZeppelinWebSocketClientTest {
+
+  @Test
+  void upgradeRequestUsesCookieAndTheCorrespondingHttpOrigin() throws Exception {
+    ClientUpgradeRequest request = ZeppelinWebSocketClient.createUpgradeRequest(
+        new URI("wss://zeppelin.example:8443/context/ws"), "JSESSIONID=session-1");
+
+    assertEquals("JSESSIONID=session-1", request.getHeader("Cookie"));
+    assertEquals("https://zeppelin.example:8443", request.getHeader("Origin"));
+  }
+
+  @Test
+  void upgradeRequestOmitsEmptyCookieAndCanonicalizesDefaultPort() throws Exception {
+    ClientUpgradeRequest request = ZeppelinWebSocketClient.createUpgradeRequest(
+        new URI("ws://zeppelin.example:80/ws"), "");
+
+    assertNull(request.getHeader("Cookie"));
+    assertEquals("http://zeppelin.example", request.getHeader("Origin"));
+  }
 
   @Test
   void connectFailsFastWhenPortClosed() {

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -105,6 +105,7 @@ abstract public class AbstractZeppelinIT {
       // ignore if jQuery/Bootstrap not ready
     }
     ZeppelinITUtils.sleep(500, false);
+    waitForWebSocketConnection();
   }
 
   private WebElement angularModelWait(By locator) {
@@ -141,6 +142,12 @@ abstract public class AbstractZeppelinIT {
     }
     manager.getWebDriver().navigate().refresh();
     visibilityWait(loggedInUserMenuLocator(), MAX_BROWSER_TIMEOUT_SEC);
+    waitForWebSocketConnection();
+  }
+
+  private void waitForWebSocketConnection() {
+    visibilityWait(By.xpath("//i[@uib-tooltip='WebSocket Connected']"),
+        MAX_BROWSER_TIMEOUT_SEC);
   }
 
   // Shared locator for the logged-in navbar user menu button. Uses a class-order-agnostic

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -161,8 +161,12 @@ public class WebDriverManager implements Closeable {
         (new WebDriverWait(driver, Duration.ofSeconds(60))).until(new ExpectedCondition<Boolean>() {
           @Override
           public Boolean apply(WebDriver d) {
-            return d.findElement(By.xpath("//i[@uib-tooltip='WebSocket Connected']"))
-                .isDisplayed();
+            boolean websocketConnected =
+                d.findElements(By.xpath("//i[@uib-tooltip='WebSocket Connected']"))
+                    .stream().anyMatch(element -> element.isDisplayed());
+            boolean authenticationRequired = d.findElements(By.id("loginModal"))
+                .stream().anyMatch(element -> element.isDisplayed());
+            return websocketConnected || authenticationRequired;
           }
         });
         loaded = true;

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientWithAuthIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientWithAuthIntegrationTest.java
@@ -24,7 +24,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.zeppelin.MiniZeppelinServer;
 import org.apache.zeppelin.client.ClientConfig;
+import org.apache.zeppelin.client.ZSession;
 import org.apache.zeppelin.client.ZeppelinClient;
+import org.apache.zeppelin.client.websocket.SimpleMessageHandler;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.junit.jupiter.api.AfterAll;
@@ -50,14 +52,19 @@ class ZeppelinClientWithAuthIntegrationTest extends AbstractTestRestApi {
     zepServer.copyBinDir();
     zepServer.getZeppelinConfiguration().setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HELIUM_REGISTRY.getVarName(),
         "helium");
-    zepServer.getZeppelinConfiguration().setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_ALLOWED_ORIGINS.getVarName(), "*");
     zepServer.start();
+    zepServer.getZeppelinConfiguration().setProperty(
+        ZeppelinConfiguration.ConfVars.ZEPPELIN_ALLOWED_ORIGINS.getVarName(),
+        "http://localhost:" + zepServer.getZeppelinConfiguration().getServerPort());
     clientConfig = new ClientConfig("http://localhost:" + zepServer.getZeppelinConfiguration().getServerPort());
     zeppelinClient = new ZeppelinClient(clientConfig);
   }
 
   @AfterAll
   static void destroy() throws Exception {
+    if (zeppelinClient != null) {
+      zeppelinClient.close();
+    }
     zepServer.destroy();
   }
 
@@ -88,6 +95,19 @@ class ZeppelinClientWithAuthIntegrationTest extends AbstractTestRestApi {
     zeppelinClient.login("admin", "password1");
     String response = zeppelinClient.createNote("/note_2");
     assertNotNull(response);
+  }
+
+  @Test
+  void testAuthenticatedZSessionWebSocket() throws Exception {
+    try (ZSession session = ZSession.builder()
+        .setClientConfig(clientConfig)
+        .setInterpreter("md")
+        .build()) {
+      session.login("admin", "password1");
+      session.start(new SimpleMessageHandler());
+
+      assertNotNull(session.getNoteId());
+    }
   }
 
   @Test

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
@@ -509,7 +509,7 @@ public class KerberosRealm extends AuthorizingRealm {
                 isCookiePersistent(), isHttps);
           }
           KerberosToken kerberosToken = new KerberosToken(token.getUserName(), token.toString());
-          SecurityUtils.getSubject().login(kerberosToken);
+          loginIfNecessary(SecurityUtils.getSubject(), kerberosToken);
           doFilter(filterChain, httpRequest, httpResponse);
         }
       } else {
@@ -546,6 +546,15 @@ public class KerberosRealm extends AuthorizingRealm {
         }
       }
     }
+  }
+
+  void loginIfNecessary(
+      org.apache.shiro.subject.Subject subject, KerberosToken kerberosToken) {
+    if (subject.isAuthenticated()
+        && Objects.equals(subject.getPrincipal(), kerberosToken.getPrincipal())) {
+      return;
+    }
+    subject.login(kerberosToken);
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/AbstractRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/AbstractRestApi.java
@@ -18,14 +18,11 @@
 package org.apache.zeppelin.rest;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 import jakarta.ws.rs.WebApplicationException;
 
 import org.apache.zeppelin.service.AuthenticationService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.apache.zeppelin.service.SimpleServiceCallback;
-import org.apache.zeppelin.user.AuthenticationInfo;
 
 import com.google.gson.Gson;
 
@@ -40,12 +37,7 @@ public class AbstractRestApi {
   }
 
   protected ServiceContext getServiceContext() {
-    AuthenticationInfo authInfo = new AuthenticationInfo(authenticationService.getPrincipal());
-    authInfo.setRoles(authenticationService.getAssociatedRoles());
-    Set<String> userAndRoles = new HashSet<>();
-    userAndRoles.add(authenticationService.getPrincipal());
-    userAndRoles.addAll(authenticationService.getAssociatedRoles());
-    return new ServiceContext(authInfo, userAndRoles);
+    return authenticationService.getAuthenticatedIdentity().toServiceContext();
   }
 
   public static class RestServiceCallback<T> extends SimpleServiceCallback<T> {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -179,12 +179,14 @@ public class LoginRestApi extends AbstractRestApi {
     return false;
   }
 
-  private JsonResponse<Map<String, String>> proceedToLogin(Subject currentUser, AuthenticationToken token) {
+  JsonResponse<Map<String, String>> proceedToLogin(
+      Subject currentUser, AuthenticationToken token) {
     JsonResponse<Map<String, String>> response = null;
     try {
-      logoutCurrentUser();
-      currentUser.getSession(true);
+      logoutCurrentUser(currentUser);
       currentUser.login(token);
+      // Shiro rotates the session during login; only retain the final authenticated session.
+      currentUser.getSession(true);
 
       Set<String> roles = authenticationService.getAssociatedRoles();
       String principal = authenticationService.getPrincipal();
@@ -215,7 +217,8 @@ public class LoginRestApi extends AbstractRestApi {
    * Post Login
    * Returns userName & password
    * for anonymous access, username is always anonymous.
-   * After getting this ticket, access through websockets become safe
+   * The ticket remains in the response for legacy client compatibility. WebSocket authentication
+   * uses the Shiro session cookie established by this request.
    *
    * @return 200 response
    */
@@ -224,19 +227,10 @@ public class LoginRestApi extends AbstractRestApi {
   public Response postLogin(@FormParam("userName") String userName,
       @FormParam("password") String password) {
     LOGGER.debug("userName: {}", userName);
-    // ticket set to anonymous for anonymous user. Simplify testing.
     Subject currentUser = SecurityUtils.getSubject();
-    if (currentUser.isAuthenticated()) {
-      currentUser.logout();
-    }
     LOGGER.debug("currentUser: {}", currentUser);
-    JsonResponse<Map<String, String>> response = null;
-    if (!currentUser.isAuthenticated()) {
-
-      UsernamePasswordToken token = new UsernamePasswordToken(userName, password);
-
-      response = proceedToLogin(currentUser, token);
-    }
+    UsernamePasswordToken token = new UsernamePasswordToken(userName, password);
+    JsonResponse<Map<String, String>> response = proceedToLogin(currentUser, token);
 
     if (response == null) {
       response = new JsonResponse<>(Response.Status.FORBIDDEN, "", null);
@@ -290,9 +284,11 @@ public class LoginRestApi extends AbstractRestApi {
   }
 
   private void logoutCurrentUser() {
-    Subject currentUser = SecurityUtils.getSubject();
+    logoutCurrentUser(SecurityUtils.getSubject());
+  }
+
+  private void logoutCurrentUser(Subject currentUser) {
     TicketContainer.instance.removeTicket(authenticationService.getPrincipal());
-    currentUser.getSession().stop();
     currentUser.logout();
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/FailClosedShiroFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/FailClosedShiroFilter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.server;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.web.env.IniWebEnvironment;
+import org.apache.shiro.web.env.WebEnvironment;
+import org.apache.shiro.web.filter.mgt.DefaultFilterChainManager;
+import org.apache.shiro.web.filter.mgt.FilterChainManager;
+import org.apache.shiro.web.filter.mgt.FilterChainResolver;
+import org.apache.shiro.web.filter.mgt.PathMatchingFilterChainResolver;
+import org.apache.shiro.web.servlet.ShiroFilter;
+import org.apache.shiro.web.util.WebUtils;
+
+/** Shiro filter that rejects requests not covered by an explicit {@code [urls]} rule. */
+public class FailClosedShiroFilter extends ShiroFilter {
+
+  private static final String NO_MATCHING_CHAIN = "No matching Shiro URL rule";
+
+  @Override
+  public void init() throws Exception {
+    super.init();
+    WebEnvironment environment = WebUtils.getRequiredWebEnvironment(getServletContext());
+    if (environment instanceof IniWebEnvironment) {
+      removeImplicitDefaultChain(
+          ((IniWebEnvironment) environment).getIni(), getFilterChainResolver());
+    }
+  }
+
+  static void removeImplicitDefaultChain(Ini ini, FilterChainResolver resolver) {
+    Ini.Section urls = ini == null ? null : ini.getSection("urls");
+    if (urls != null && urls.containsKey("/**")) {
+      return;
+    }
+    if (!(resolver instanceof PathMatchingFilterChainResolver)) {
+      return;
+    }
+
+    FilterChainManager manager =
+        ((PathMatchingFilterChainResolver) resolver).getFilterChainManager();
+    if (manager instanceof DefaultFilterChainManager) {
+      // Shiro adds an implicit /** chain containing only its global invalid-request filter.
+      // It is not an operator-configured [urls] rule, so remove it and let this filter reject
+      // otherwise unmatched requests.
+      ((DefaultFilterChainManager) manager).getFilterChains().remove("/**");
+    }
+  }
+
+  @Override
+  protected FilterChain getExecutionChain(
+      ServletRequest request, ServletResponse response, FilterChain originalChain) {
+    FilterChainResolver resolver = getFilterChainResolver();
+    FilterChain resolvedChain =
+        resolver == null ? null : resolver.getChain(request, response, originalChain);
+    if (resolvedChain != null) {
+      return resolvedChain;
+    }
+
+    return (ignoredRequest, deniedResponse) ->
+        ((HttpServletResponse) deniedResponse)
+            .sendError(HttpServletResponse.SC_FORBIDDEN, NO_MATCHING_CHAIN);
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -59,7 +59,6 @@ import jakarta.websocket.server.ServerEndpointConfig;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.web.env.EnvironmentLoaderListener;
-import org.apache.shiro.web.servlet.ShiroFilter;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.DEFAULT_UI;
@@ -118,6 +117,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer;
+import org.eclipse.jetty.websocket.servlet.WebSocketUpgradeFilter;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.ServiceLocatorFactory;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
@@ -189,6 +189,7 @@ public class ZeppelinServer implements AutoCloseable {
             bindAsContract(AdminService.class).in(Singleton.class);
             bindAsContract(AuthorizationService.class).in(Singleton.class);
             bindAsContract(ConnectionManager.class).in(Singleton.class);
+            bindAsContract(AuthenticatedSessionService.class).in(Singleton.class);
             bindAsContract(NoteManager.class).in(Singleton.class);
             bind(AuthenticationServiceFactory.getAuthServiceClass(zConf))
                     .to(AuthenticationService.class)
@@ -476,7 +477,7 @@ public class ZeppelinServer implements AutoCloseable {
             .configure(webapp, (servletContext, wsContainer) -> {
               wsContainer.setDefaultMaxTextMessageBufferSize(Integer.parseInt(maxTextMessageSize));
               wsContainer.addEndpoint(ServerEndpointConfig.Builder.create(NotebookServer.class, "/ws")
-              .configurator(new SessionConfigurator(sharedServiceLocator)).build());
+              .configurator(new SessionConfigurator(sharedServiceLocator, zConf)).build());
             });
   }
 
@@ -563,9 +564,21 @@ public class ZeppelinServer implements AutoCloseable {
     String shiroIniPath = zConf.getShiroPath();
     if (!StringUtils.isBlank(shiroIniPath)) {
       webapp.setInitParameter("shiroConfigLocations", new File(shiroIniPath).toURI().toString());
-      webapp
-          .addFilter(ShiroFilter.class, "/api/*", EnumSet.allOf(DispatcherType.class))
-          .setInitParameter("staticSecurityManagerEnabled", "true");
+      FilterHolder shiroFilter =
+          webapp.addFilter(
+              FailClosedShiroFilter.class,
+              "/api/*",
+              EnumSet.allOf(DispatcherType.class));
+      shiroFilter.setInitParameter("staticSecurityManagerEnabled", "true");
+
+      // Jetty's WebSocket initializer otherwise prepends its upgrade filter. Register the
+      // authentication and upgrade filters explicitly so REST and WebSocket handshakes use the
+      // same Shiro URL policy before an upgrade can occur.
+      webapp.addFilter(shiroFilter, "/ws", EnumSet.allOf(DispatcherType.class));
+      FilterHolder upgradeFilter = new FilterHolder(WebSocketUpgradeFilter.class);
+      upgradeFilter.setName(WebSocketUpgradeFilter.class.getName());
+      upgradeFilter.setAsyncSupported(true);
+      webapp.addFilter(upgradeFilter, "/*", EnumSet.of(DispatcherType.REQUEST));
       webapp.addEventListener(new EnvironmentLoaderListener());
     }
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/AuthenticatedIdentity.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/AuthenticatedIdentity.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.service;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.zeppelin.user.AuthenticationInfo;
+
+/** Immutable identity captured from the server-side authentication layer. */
+public final class AuthenticatedIdentity {
+
+  public static final String ANONYMOUS_PRINCIPAL = "anonymous";
+
+  private static final AuthenticatedIdentity ANONYMOUS =
+      new AuthenticatedIdentity(ANONYMOUS_PRINCIPAL, Collections.emptySet(), false, null);
+
+  private final String principal;
+  private final Set<String> roles;
+  private final boolean authenticated;
+  private final Serializable sessionId;
+
+  public AuthenticatedIdentity(
+      String principal, Set<String> roles, boolean authenticated, Serializable sessionId) {
+    this.principal = Objects.requireNonNull(principal, "principal");
+    this.roles = Collections.unmodifiableSet(new HashSet<>(Objects.requireNonNull(roles, "roles")));
+    this.authenticated = authenticated;
+    this.sessionId = sessionId;
+  }
+
+  public static AuthenticatedIdentity anonymous() {
+    return ANONYMOUS;
+  }
+
+  public String getPrincipal() {
+    return principal;
+  }
+
+  public Set<String> getRoles() {
+    return roles;
+  }
+
+  public boolean isAuthenticated() {
+    return authenticated;
+  }
+
+  /** Return the opaque server-side session handle, if authentication created one. */
+  public Optional<Serializable> getSessionId() {
+    return Optional.ofNullable(sessionId);
+  }
+
+  /** Build the authorization context consumed by REST and WebSocket services. */
+  public ServiceContext toServiceContext() {
+    Set<String> copiedRoles = new HashSet<>(roles);
+    AuthenticationInfo authenticationInfo =
+        new AuthenticationInfo(principal, copiedRoles, null);
+    Set<String> userAndRoles = new HashSet<>(copiedRoles);
+    userAndRoles.add(principal);
+    return new ServiceContext(authenticationInfo, userAndRoles);
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/AuthenticatedSessionService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/AuthenticatedSessionService.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.service;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.Subject;
+
+/** Revalidates the Shiro session captured when a long-lived transport was established. */
+public class AuthenticatedSessionService {
+
+  private final Provider<AuthenticationService> authenticationServiceProvider;
+
+  @Inject
+  public AuthenticatedSessionService(
+      Provider<AuthenticationService> authenticationServiceProvider) {
+    this.authenticationServiceProvider = authenticationServiceProvider;
+  }
+
+  /** Validate a captured session without extending its idle timeout or resolving roles. */
+  public void validate(
+      AuthenticatedIdentity connectionIdentity, SecurityManager securityManager) {
+    try {
+      Subject subject = restoreValidatedSubject(connectionIdentity, securityManager);
+      if (subject == null) {
+        return;
+      }
+      String principal = subject.execute(
+          () -> authenticationServiceProvider.get().getPrincipal());
+      if (!connectionIdentity.getPrincipal().equals(principal)) {
+        throw new SessionAuthenticationException("Authenticated session identity changed");
+      }
+    } catch (SessionAuthenticationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new SessionAuthenticationException("Authenticated session is no longer valid", e);
+    }
+  }
+
+  /**
+   * Revalidate a captured session and return a fresh server-authenticated identity.
+   *
+   * @param touchSession whether this client operation should extend the session idle timeout
+   */
+  public AuthenticatedIdentity refresh(
+      AuthenticatedIdentity connectionIdentity,
+      SecurityManager securityManager,
+      boolean touchSession) {
+    try {
+      Subject subject = restoreValidatedSubject(connectionIdentity, securityManager);
+      if (subject == null) {
+        return AuthenticatedIdentity.anonymous();
+      }
+
+      Session session = subject.getSession(false);
+      if (touchSession) {
+        session.touch();
+      }
+      AuthenticatedIdentity refreshed =
+          subject.execute(
+              () -> authenticationServiceProvider.get().getAuthenticatedIdentity());
+      Serializable sessionId = connectionIdentity.getSessionId().orElseThrow(
+          () -> new SessionAuthenticationException("Authenticated session is unavailable"));
+      if (!refreshed.isAuthenticated()
+          || !connectionIdentity.getPrincipal().equals(refreshed.getPrincipal())
+          || refreshed.getSessionId().filter(sessionId::equals).isEmpty()) {
+        throw new SessionAuthenticationException("Authenticated session identity changed");
+      }
+      return refreshed;
+    } catch (SessionAuthenticationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new SessionAuthenticationException("Authenticated session is no longer valid", e);
+    }
+  }
+
+  private Subject restoreValidatedSubject(
+      AuthenticatedIdentity connectionIdentity, SecurityManager securityManager) {
+    Objects.requireNonNull(connectionIdentity, "connectionIdentity");
+    if (!connectionIdentity.isAuthenticated()
+        && AuthenticatedIdentity.ANONYMOUS_PRINCIPAL.equals(
+            connectionIdentity.getPrincipal())
+        && connectionIdentity.getSessionId().isEmpty()) {
+      return null;
+    }
+
+    Serializable sessionId = connectionIdentity.getSessionId().orElseThrow(
+        () -> new SessionAuthenticationException("Authenticated session is unavailable"));
+    if (!connectionIdentity.isAuthenticated() || securityManager == null) {
+      throw new SessionAuthenticationException("Authenticated session is unavailable");
+    }
+
+    Subject subject = restoreSubject(sessionId, securityManager);
+    Session session = subject.getSession(false);
+    if (session == null || !subject.isAuthenticated() || !sessionId.equals(session.getId())) {
+      throw new SessionAuthenticationException("Authenticated session is no longer valid");
+    }
+    return subject;
+  }
+
+  Subject restoreSubject(Serializable sessionId, SecurityManager securityManager) {
+    return new Subject.Builder(securityManager)
+        .sessionId(sessionId)
+        .sessionCreationEnabled(false)
+        .buildSubject();
+  }
+
+  /** Indicates that a transport's server-authenticated session is no longer valid. */
+  public static final class SessionAuthenticationException extends RuntimeException {
+
+    public SessionAuthenticationException(String message) {
+      super(message);
+    }
+
+    public SessionAuthenticationException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/AuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/AuthenticationService.java
@@ -30,6 +30,13 @@ import org.apache.shiro.realm.Realm;
 public interface AuthenticationService {
 
   /**
+   * Capture the identity bound to the current request as one immutable snapshot.
+   *
+   * @return current principal, roles, authentication state and opaque session handle
+   */
+  AuthenticatedIdentity getAuthenticatedIdentity();
+
+  /**
    * Get current principal/username.
    * @return
    */

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NoAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NoAuthenticationService.java
@@ -39,6 +39,11 @@ public class NoAuthenticationService implements AuthenticationService {
   }
 
   @Override
+  public AuthenticatedIdentity getAuthenticatedIdentity() {
+    return AuthenticatedIdentity.anonymous();
+  }
+
+  @Override
   public String getPrincipal() {
     return ANONYMOUS;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -1376,7 +1376,7 @@ public class NotebookService {
       notebook.processNote(noteId,
         note -> {
           Paragraph p = setParagraphUsingMessage(note, message, paragraphId,
-            text, title, params, config);
+            text, title, params, config, context.getAutheInfo());
           p.setResult((InterpreterResult) message.get("results"));
           p.setErrorMessage((String) message.get("errorMessage"));
           p.setStatusWithoutNotification(status);
@@ -1422,10 +1422,9 @@ public class NotebookService {
 
   private Paragraph setParagraphUsingMessage(Note note, Message fromMessage, String paragraphId,
                                              String text, String title, Map<String, Object> params,
-                                             Map<String, Object> config) {
+                                             Map<String, Object> config,
+                                             AuthenticationInfo subject) {
     Paragraph p = note.getParagraph(paragraphId);
-    AuthenticationInfo subject =
-        new AuthenticationInfo(fromMessage.principal, fromMessage.roles, fromMessage.ticket);
     // In personalized mode only the note owner may update the master paragraph, so that
     // new users inherit the owner's changes while a non-owner's changes stay in their copy.
     if (!note.isPersonalizedMode()

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.zeppelin.service;
 
+import java.io.Serializable;
 import java.security.Principal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -47,6 +48,7 @@ import org.apache.shiro.realm.jdbc.JdbcRealm;
 import org.apache.shiro.realm.ldap.DefaultLdapRealm;
 import org.apache.shiro.realm.ldap.JndiLdapContextFactory;
 import org.apache.shiro.realm.text.IniRealm;
+import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.JdbcUtils;
@@ -85,10 +87,15 @@ public class ShiroAuthenticationService implements AuthenticationService {
     this.zConf = zConf;
     if (zConf.getShiroPath().length() > 0) {
       try {
+        DefaultSecurityManager securityManager =
+            (DefaultSecurityManager) ThreadContext.getSecurityManager();
+        if (securityManager == null) {
+          throw new UnavailableSecurityManagerException(
+              "No Shiro SecurityManager is bound to the current request");
+        }
         Collection<Realm> realms =
-            ((DefaultSecurityManager) org.apache.shiro.SecurityUtils.getSecurityManager())
-                .getRealms();
-        if (realms.size() > 1) {
+            securityManager.getRealms();
+        if (realms != null && realms.size() > 1) {
           boolean isIniRealmEnabled = false;
           for (Realm realm : realms) {
             if (realm instanceof IniRealm && ((IniRealm) realm).getIni().get("users") != null) {
@@ -108,6 +115,21 @@ public class ShiroAuthenticationService implements AuthenticationService {
     }
   }
 
+  /** Capture the current Shiro subject as one immutable identity snapshot. */
+  @Override
+  public AuthenticatedIdentity getAuthenticatedIdentity() {
+    Subject subject = org.apache.shiro.SecurityUtils.getSubject();
+    if (!subject.isAuthenticated()) {
+      return AuthenticatedIdentity.anonymous();
+    }
+
+    String principal = getAuthenticatedPrincipal(subject);
+    Set<String> roles = getAssociatedRoles(subject, principal);
+    Session session = subject.getSession(false);
+    Serializable sessionId = session == null ? null : session.getId();
+    return new AuthenticatedIdentity(principal, roles, true, sessionId);
+  }
+
   /**
    * Return the authenticated user if any otherwise returns "anonymous".
    *
@@ -116,19 +138,23 @@ public class ShiroAuthenticationService implements AuthenticationService {
   @Override
   public String getPrincipal() {
     Subject subject = org.apache.shiro.SecurityUtils.getSubject();
-
-    String principal;
-    if (subject.isAuthenticated()) {
-      principal = extractPrincipal(subject);
-      if (zConf.isUsernameForceLowerCase()) {
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug("Converting principal name {} to lower case: {}", principal, principal.toLowerCase());
-        }
-        principal = principal.toLowerCase();
-      }
-    } else {
+    if (!subject.isAuthenticated()) {
       // TODO(jl): Could be better to occur error?
-      principal = "anonymous";
+      return AuthenticatedIdentity.ANONYMOUS_PRINCIPAL;
+    }
+    return getAuthenticatedPrincipal(subject);
+  }
+
+  private String getAuthenticatedPrincipal(Subject subject) {
+    String principal = extractPrincipal(subject);
+    if (zConf.isUsernameForceLowerCase()) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "Converting principal name {} to lower case: {}",
+            principal,
+            principal.toLowerCase());
+      }
+      principal = principal.toLowerCase();
     }
     return principal;
   }
@@ -228,43 +254,48 @@ public class ShiroAuthenticationService implements AuthenticationService {
   @Override
   public Set<String> getAssociatedRoles() {
     Subject subject = org.apache.shiro.SecurityUtils.getSubject();
+    if (!subject.isAuthenticated()) {
+      return new HashSet<>();
+    }
+    return getAssociatedRoles(subject, getAuthenticatedPrincipal(subject));
+  }
+
+  private Set<String> getAssociatedRoles(Subject subject, String principal) {
     Set<String> roles = new HashSet<>();
     Map<String, String> allRoles = null;
 
-    if (subject.isAuthenticated()) {
-      Collection<Realm> realmsList = getRealmsList();
-      for (Realm realm : realmsList) {
-        String name = realm.getClass().getName();
-        if (INI_REALM.equals(name)) {
-          allRoles = ((IniRealm) realm).getIni().get("roles");
-          break;
-        } else if (LDAP_REALM.equals(name)) {
-          try {
-            AuthorizationInfo auth =
-                ((LdapRealm) realm)
-                    .queryForAuthorizationInfo(
-                        new SimplePrincipalCollection(subject.getPrincipal(), realm.getName()),
-                        ((LdapRealm) realm).getContextFactory());
-            if (auth != null) {
-              roles = new HashSet<>(auth.getRoles());
-            }
-          } catch (NamingException e) {
-            LOGGER.error("Can't fetch roles", e);
+    Collection<Realm> realmsList = getRealmsList();
+    for (Realm realm : realmsList) {
+      String name = realm.getClass().getName();
+      if (INI_REALM.equals(name)) {
+        allRoles = ((IniRealm) realm).getIni().get("roles");
+        break;
+      } else if (LDAP_REALM.equals(name)) {
+        try {
+          AuthorizationInfo auth =
+              ((LdapRealm) realm)
+                  .queryForAuthorizationInfo(
+                      new SimplePrincipalCollection(subject.getPrincipal(), realm.getName()),
+                      ((LdapRealm) realm).getContextFactory());
+          if (auth != null) {
+            roles = new HashSet<>(auth.getRoles());
           }
-          break;
-        } else if (ACTIVE_DIRECTORY_GROUP_REALM.equals(name)) {
-          allRoles = ((ActiveDirectoryGroupRealm) realm).getListRoles();
-          break;
-        } else if (realm instanceof KnoxJwtRealm) {
-          roles = ((KnoxJwtRealm) realm).mapGroupPrincipals(getPrincipal());
-          break;
+        } catch (NamingException e) {
+          LOGGER.error("Can't fetch roles", e);
         }
+        break;
+      } else if (ACTIVE_DIRECTORY_GROUP_REALM.equals(name)) {
+        allRoles = ((ActiveDirectoryGroupRealm) realm).getListRoles();
+        break;
+      } else if (realm instanceof KnoxJwtRealm) {
+        roles = ((KnoxJwtRealm) realm).mapGroupPrincipals(principal);
+        break;
       }
-      if (allRoles != null) {
-        for (Map.Entry<String, String> pair : allRoles.entrySet()) {
-          if (subject.hasRole(pair.getKey())) {
-            roles.add(pair.getKey());
-          }
+    }
+    if (allRoles != null) {
+      for (Map.Entry<String, String> pair : allRoles.entrySet()) {
+        if (subject.hasRole(pair.getKey())) {
+          roles.add(pair.getKey());
         }
       }
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -26,8 +26,6 @@ import io.micrometer.core.instrument.Tags;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.SocketTimeoutException;
-import java.net.URISyntaxException;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -53,6 +51,7 @@ import jakarta.websocket.server.ServerEndpoint;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.shiro.mgt.SecurityManager;
 import org.apache.thrift.TException;
 import org.apache.zeppelin.common.Message;
 import org.apache.zeppelin.common.Message.OP;
@@ -86,17 +85,18 @@ import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl.Revision
 import org.apache.zeppelin.rest.exception.ForbiddenException;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
+import org.apache.zeppelin.service.AuthenticatedIdentity;
+import org.apache.zeppelin.service.AuthenticatedSessionService;
 import org.apache.zeppelin.service.ConfigurationService;
 import org.apache.zeppelin.service.JobManagerService;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
+import org.apache.zeppelin.service.AuthenticatedSessionService.SessionAuthenticationException;
 import org.apache.zeppelin.service.SimpleServiceCallback;
 import org.apache.zeppelin.service.exception.JobManagerForbiddenException;
-import org.apache.zeppelin.ticket.TicketContainer;
 import org.apache.zeppelin.types.InterpreterSettingsList;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.util.IdHashes;
-import org.apache.zeppelin.utils.CorsUtils;
 import org.apache.zeppelin.utils.ServerUtils;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
@@ -106,7 +106,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.zeppelin.common.Message.MSG_ID_NOT_DEFINED;
-import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_ALLOWED_ORIGINS;
 
 /**
  * Zeppelin websocket service. This class used setter injection because all servlet should have
@@ -149,6 +148,7 @@ public class NotebookServer implements AngularObjectRegistryListener,
   // TODO(jl): This will be removed by handling session directly
   private final Map<String, NotebookSocket> sessionIdNotebookSocketMap = Metrics.gaugeMapSize("zeppelin_session_id_notebook_sockets", Tags.empty(), new ConcurrentHashMap<>());
   private ConnectionManager connectionManager;
+  private AuthenticatedSessionService authenticatedSessionService;
   private ZeppelinConfiguration zConf;
   private Provider<Notebook> notebookProvider;
   private Provider<NoteParser> noteParser;
@@ -207,6 +207,12 @@ public class NotebookServer implements AngularObjectRegistryListener,
     return this.connectionManager;
   }
 
+  @Inject
+  public void setAuthenticatedSessionService(
+      AuthenticatedSessionService authenticatedSessionService) {
+    this.authenticatedSessionService = authenticatedSessionService;
+  }
+
 
   @Inject
   public void setConfigurationService(
@@ -236,40 +242,62 @@ public class NotebookServer implements AngularObjectRegistryListener,
     return jobManagerServiceProvider.get();
   }
 
-  public boolean checkOrigin(String origin) {
-    try {
-      return CorsUtils.isValidOrigin(origin, zConf);
-    } catch (UnknownHostException | URISyntaxException e) {
-      LOGGER.error(e.toString(), e);
-    }
-    return false;
-  }
-
   @OnOpen
   public void onOpen(Session session, EndpointConfig endpointConfig) throws IOException {
 
     LOGGER.info("Open connection to {} with Session: {}, config: {}", ServerUtils.getRemoteAddress(session), session, endpointConfig.getUserProperties().keySet());
 
     Map<String, Object> headers = endpointConfig.getUserProperties();
-    String origin = String.valueOf(headers.get(CorsUtils.HEADER_ORIGIN));
-    if (checkOrigin(origin)) {
-      NotebookSocket notebookSocket = sessionIdNotebookSocketMap
-          .computeIfAbsent(session.getId(), unused -> new NotebookSocket(session, headers));
+    Object capturedIdentity = headers.get(SessionConfigurator.AUTHENTICATED_IDENTITY);
+    if (!(capturedIdentity instanceof AuthenticatedIdentity)) {
+      session.close(new CloseReason(
+          CloseReason.CloseCodes.VIOLATED_POLICY,
+          "Authentication state was not established"));
+      return;
+    }
+
+    SecurityManager securityManager = (SecurityManager) headers.get(
+        SessionConfigurator.AUTHENTICATION_SECURITY_MANAGER);
+    NotebookSocket notebookSocket = null;
+    try {
+      AuthenticatedIdentity identity = authenticatedSessionService.refresh(
+          (AuthenticatedIdentity) capturedIdentity, securityManager, false);
+      notebookSocket = new NotebookSocket(
+          session, headers, identity, securityManager, authenticatedSessionService);
+      sessionIdNotebookSocketMap.put(session.getId(), notebookSocket);
       onOpen(notebookSocket);
-    } else {
-      LOGGER.error("Websocket request is not allowed by {} settings. Origin: {}", ZEPPELIN_ALLOWED_ORIGINS,
-          origin);
-      session.close();
+      // Close the race between initial validation and connection registration.
+      authenticatedSessionService.validate(identity, securityManager);
+    } catch (SessionAuthenticationException e) {
+      if (notebookSocket != null) {
+        sessionIdNotebookSocketMap.remove(session.getId(), notebookSocket);
+        removeConnection(notebookSocket);
+      }
+      session.close(new CloseReason(
+          CloseReason.CloseCodes.VIOLATED_POLICY,
+          "Authentication session is no longer valid"));
     }
   }
 
   public void onOpen(NotebookSocket conn) {
     connectionManager.addConnection(conn);
+    connectionManager.addUserConnection(
+        conn.getAuthenticatedIdentity().getPrincipal(), conn);
   }
 
   @OnMessage
   public void onMessage(Session session, String msg) {
     NotebookSocket conn = sessionIdNotebookSocketMap.get(session.getId());
+    if (conn == null) {
+      try {
+        session.close(new CloseReason(
+            CloseReason.CloseCodes.VIOLATED_POLICY,
+            "Authentication state was not established"));
+      } catch (IOException e) {
+        LOGGER.debug("Failed to close unregistered WebSocket session", e);
+      }
+      return;
+    }
     onMessage(conn, msg);
   }
 
@@ -277,34 +305,23 @@ public class NotebookServer implements AngularObjectRegistryListener,
     Message receivedMessage = null;
     try {
       receivedMessage = deserializeMessage(msg);
+      String authenticatedPrincipal = conn.getAuthenticatedIdentity() == null
+          ? "unknown" : conn.getAuthenticatedIdentity().getPrincipal();
       if (receivedMessage.op != OP.PING) {
         LOGGER.debug("WebSocket message received: operation={}, principal={}",
-            receivedMessage.op, receivedMessage.principal);
+            receivedMessage.op, authenticatedPrincipal);
       }
       LOGGER.trace("WebSocket message processing started: operation={}, principal={}",
-          receivedMessage.op, receivedMessage.principal);
+          receivedMessage.op, authenticatedPrincipal);
 
-      TicketContainer.Entry ticketEntry = TicketContainer.instance.getTicketEntry(receivedMessage.principal);
-      if (ticketEntry == null || StringUtils.isEmpty(ticketEntry.getTicket())) {
-        LOGGER.debug("{} message: no ticket on file for principal {}",
-            receivedMessage.op, receivedMessage.principal);
-        return;
-      } else if (!ticketEntry.getTicket().equals(receivedMessage.ticket)) {
-        /* not to pollute logs, log instead of exception */
-        LOGGER.debug("{} message: ticket mismatch for principal {}",
-            receivedMessage.op, receivedMessage.principal);
-        if (!receivedMessage.op.equals(OP.PING)) {
-          conn.send(serializeMessage(new Message(OP.SESSION_LOGOUT).put("info",
-              "Your ticket is invalid possibly due to server restart. Please login again.")));
-        }
-
-        return;
-      }
-
-      boolean allowAnonymous = zConf.isAnonymousAllowed();
-      if (!allowAnonymous && receivedMessage.principal.equals("anonymous")) {
-        LOGGER.warn("Anonymous access not allowed.");
-        return;
+      AuthenticatedIdentity identity;
+      if (receivedMessage.op == OP.PING) {
+        authenticatedSessionService.validate(
+            conn.getAuthenticatedIdentity(), conn.getAuthenticationSecurityManager());
+        identity = conn.getAuthenticatedIdentity();
+      } else {
+        identity = authenticatedSessionService.refresh(
+            conn.getAuthenticatedIdentity(), conn.getAuthenticationSecurityManager(), true);
       }
 
       if (Message.isDisabledForRunningNotes(receivedMessage.op)) {
@@ -315,10 +332,7 @@ public class NotebookServer implements AngularObjectRegistryListener,
         }
       }
 
-      if (StringUtils.isEmpty(conn.getUser())) {
-        connectionManager.addUserConnection(receivedMessage.principal, conn);
-      }
-      ServiceContext context = getServiceContext(ticketEntry);
+      ServiceContext context = identity.toServiceContext();
       // Lets be elegant here
       switch (receivedMessage.op) {
         case LIST_NOTES:
@@ -485,11 +499,22 @@ public class NotebookServer implements AngularObjectRegistryListener,
         default:
           break;
       }
+    } catch (SessionAuthenticationException e) {
+      LOGGER.debug("Closing WebSocket with invalid authentication session: errorType={}",
+          e.getClass().getSimpleName());
+      try {
+        conn.close(new CloseReason(
+            CloseReason.CloseCodes.VIOLATED_POLICY,
+            "Authentication session is no longer valid"));
+      } catch (IOException closeException) {
+        LOGGER.debug("Failed to close WebSocket with invalid authentication session: errorType={}",
+            closeException.getClass().getSimpleName());
+      }
     } catch (Exception e) {
       String operation = receivedMessage == null || receivedMessage.op == null
           ? "unknown" : receivedMessage.op.name();
-      String principal = receivedMessage == null || StringUtils.isEmpty(receivedMessage.principal)
-          ? "unknown" : receivedMessage.principal;
+      String principal = conn.getAuthenticatedIdentity() == null
+          ? "unknown" : conn.getAuthenticatedIdentity().getPrincipal();
       LOGGER.error("WebSocket message handling completed: operation={}, principal={}, "
               + "success=false, errorType={}",
           operation, principal, e.getClass().getSimpleName());
@@ -1308,8 +1333,6 @@ public class NotebookServer implements AngularObjectRegistryListener,
     String interpreterGroupId = (String) fromMessage.get("interpreterGroupId");
     String varName = (String) fromMessage.get("name");
     Object varValue = fromMessage.get("value");
-    String user = fromMessage.principal;
-
     getNotebookService().updateAngularObject(noteId, paragraphId, interpreterGroupId,
         varName, varValue, context,
         new WebSocketServiceCallback<AngularObject>(conn) {
@@ -2319,15 +2342,6 @@ public class NotebookServer implements AngularObjectRegistryListener,
     Message m = new Message(OP.NOTICE);
     m.data.put("notice", message);
     connectionManager.broadcast(m);
-  }
-
-  private ServiceContext getServiceContext(TicketContainer.Entry ticketEntry) {
-    AuthenticationInfo authInfo =
-        new AuthenticationInfo(ticketEntry.getPrincipal(), ticketEntry.getRoles(), ticketEntry.getTicket());
-    Set<String> userAndRoles = new HashSet<>();
-    userAndRoles.add(authInfo.getUser());
-    userAndRoles.addAll(authInfo.getRoles());
-    return new ServiceContext(authInfo, userAndRoles);
   }
 
   public class WebSocketServiceCallback<T> extends SimpleServiceCallback<T> {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
@@ -16,15 +16,22 @@
  */
 package org.apache.zeppelin.socket;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Session;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.zeppelin.service.AuthenticatedIdentity;
+import org.apache.zeppelin.service.AuthenticatedSessionService;
+import org.apache.zeppelin.service.AuthenticatedSessionService.SessionAuthenticationException;
+import org.apache.zeppelin.util.WatcherSecurityKey;
 import org.apache.zeppelin.utils.ServerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Map;
-
-import jakarta.websocket.Session;
 
 /**
  * Notebook websocket.
@@ -32,13 +39,25 @@ import jakarta.websocket.Session;
 public class NotebookSocket {
   private static final Logger LOGGER = LoggerFactory.getLogger(NotebookSocket.class);
 
-  private Session session;
-  private Map<String, Object> headers;
+  private final Session session;
+  private final Map<String, Object> headers;
+  private final AuthenticatedIdentity authenticatedIdentity;
+  private final SecurityManager authenticationSecurityManager;
+  private final AuthenticatedSessionService authenticatedSessionService;
   private String user;
 
-  public NotebookSocket(Session session, Map<String, Object> headers) {
+  public NotebookSocket(
+      Session session,
+      Map<String, Object> headers,
+      AuthenticatedIdentity authenticatedIdentity,
+      SecurityManager authenticationSecurityManager,
+      AuthenticatedSessionService authenticatedSessionService) {
     this.session = session;
-    this.headers = headers;
+    this.headers = Collections.singletonMap(
+        WatcherSecurityKey.HTTP_HEADER, headers.get(WatcherSecurityKey.HTTP_HEADER));
+    this.authenticatedIdentity = authenticatedIdentity;
+    this.authenticationSecurityManager = authenticationSecurityManager;
+    this.authenticatedSessionService = authenticatedSessionService;
     this.user = StringUtils.EMPTY;
     LOGGER.debug("NotebookSocket created for session: {}", session.getId());
   }
@@ -48,6 +67,19 @@ public class NotebookSocket {
   }
 
   public void send(String serializeMessage) throws IOException {
+    try {
+      authenticatedSessionService.validate(
+          authenticatedIdentity, authenticationSecurityManager);
+    } catch (SessionAuthenticationException e) {
+      try {
+        close(new CloseReason(
+            CloseReason.CloseCodes.VIOLATED_POLICY,
+            "Authentication session is no longer valid"));
+      } catch (IOException closeException) {
+        e.addSuppressed(closeException);
+      }
+      throw new IOException("Authentication session is no longer valid", e);
+    }
     session.getAsyncRemote().sendText(serializeMessage, result -> {
       if (result.getException() != null) {
         LOGGER.error("Failed to send async message for User {} in Session {}: {}", this.user, this.session.getId(), result.getException());
@@ -62,6 +94,18 @@ public class NotebookSocket {
   public void setUser(String user) {
     LOGGER.debug("Setting user: {}", user);
     this.user = user;
+  }
+
+  public AuthenticatedIdentity getAuthenticatedIdentity() {
+    return authenticatedIdentity;
+  }
+
+  public SecurityManager getAuthenticationSecurityManager() {
+    return authenticationSecurityManager;
+  }
+
+  public void close(CloseReason closeReason) throws IOException {
+    session.close(closeReason);
   }
 
   @Override

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/SessionConfigurator.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/SessionConfigurator.java
@@ -16,6 +16,8 @@
  */
 package org.apache.zeppelin.socket;
 
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.List;
 
 import jakarta.websocket.HandshakeResponse;
@@ -23,19 +25,44 @@ import jakarta.websocket.server.HandshakeRequest;
 import jakarta.websocket.server.ServerEndpointConfig;
 import jakarta.websocket.server.ServerEndpointConfig.Configurator;
 
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.util.ThreadContext;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.service.AuthenticatedIdentity;
+import org.apache.zeppelin.service.AuthenticationService;
 import org.apache.zeppelin.util.WatcherSecurityKey;
 import org.apache.zeppelin.utils.CorsUtils;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class set headers to websocket sessions and inject hk2 when initiating instances by ServerEndpoint annotation.
  */
 public class SessionConfigurator extends Configurator {
 
-  private final ServiceLocator serviceLocator;
+  static final String AUTHENTICATED_IDENTITY = AuthenticatedIdentity.class.getName();
+  static final String AUTHENTICATION_SECURITY_MANAGER = SecurityManager.class.getName();
 
-  public SessionConfigurator(ServiceLocator serviceLocator) {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SessionConfigurator.class);
+
+  private final ServiceLocator serviceLocator;
+  private final ZeppelinConfiguration zConf;
+
+  public SessionConfigurator(
+      ServiceLocator serviceLocator, ZeppelinConfiguration zConf) {
     this.serviceLocator = serviceLocator;
+    this.zConf = zConf;
+  }
+
+  @Override
+  public boolean checkOrigin(String originHeaderValue) {
+    try {
+      return CorsUtils.isValidOrigin(originHeaderValue, zConf);
+    } catch (UnknownHostException | URISyntaxException e) {
+      LOGGER.warn("Rejecting WebSocket handshake with invalid Origin: {}", originHeaderValue);
+      return false;
+    }
   }
 
   @Override
@@ -45,9 +72,14 @@ public class SessionConfigurator extends Configurator {
     holder = request.getHeaders().get(WatcherSecurityKey.HTTP_HEADER);
     sec.getUserProperties().put(WatcherSecurityKey.HTTP_HEADER,
         null != holder && !holder.isEmpty() ? holder.get(0) : null);
-    holder = request.getHeaders().get(CorsUtils.HEADER_ORIGIN);
-    sec.getUserProperties().put(CorsUtils.HEADER_ORIGIN,
-        null != holder && !holder.isEmpty() ? holder.get(0) : null);
+    AuthenticationService authenticationService =
+        serviceLocator.getService(AuthenticationService.class);
+    sec.getUserProperties().put(
+        AUTHENTICATED_IDENTITY, authenticationService.getAuthenticatedIdentity());
+    SecurityManager securityManager = ThreadContext.getSecurityManager();
+    if (securityManager != null) {
+      sec.getUserProperties().put(AUTHENTICATION_SECURITY_MANAGER, securityManager);
+    }
   }
 
   @Override

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/CorsUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/CorsUtils.java
@@ -20,7 +20,9 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Locale;
+
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 
 public class CorsUtils {
@@ -30,26 +32,84 @@ public class CorsUtils {
   }
 
   public static final String HEADER_ORIGIN = "Origin";
-  public static boolean isValidOrigin(String sourceHost, ZeppelinConfiguration zConf)
+  public static boolean isValidOrigin(String sourceOrigin, ZeppelinConfiguration zConf)
       throws UnknownHostException, URISyntaxException {
-
-    String sourceUriHost = "";
-
-    if (sourceHost != null && !sourceHost.isEmpty()) {
-      sourceUriHost = new URI(sourceHost).getHost();
-      sourceUriHost = (sourceUriHost == null) ? "" : sourceUriHost.toLowerCase(Locale.ROOT);
+    if (sourceOrigin == null || sourceOrigin.isEmpty()) {
+      return false;
     }
 
-    String currentHost = InetAddress.getLocalHost().getHostName().toLowerCase(Locale.ROOT);
-    // getAllowedOrigins() returns lowercased entries; normalize sourceHost the same way
-    // before the membership check so case differences in the Origin header do not produce
-    // false rejections of explicitly configured origins.
-    String normalizedOrigin =
-        sourceHost == null ? "" : sourceHost.toLowerCase(Locale.ROOT);
+    URI origin = parseOrigin(sourceOrigin);
+    String canonicalOrigin = canonicalOrigin(origin);
+    List<String> allowedOrigins = zConf.getAllowedOrigins();
+    for (String allowedOrigin : allowedOrigins) {
+      if ("*".equals(allowedOrigin.trim())) {
+        return true;
+      }
+      try {
+        if (canonicalOrigin.equals(canonicalOrigin(parseOrigin(allowedOrigin.trim())))) {
+          return true;
+        }
+      } catch (URISyntaxException ignored) {
+        // Ignore malformed configured entries instead of broadening the allowed set.
+      }
+    }
 
-    return zConf.getAllowedOrigins().contains("*")
-        || currentHost.equals(sourceUriHost)
+    // A configured allowlist is authoritative. Localhost is the secure convenience default only
+    // when no origins were configured.
+    if (!allowedOrigins.isEmpty()) {
+      return false;
+    }
+
+    String expectedScheme = zConf.useSsl() ? "https" : "http";
+    int expectedPort = zConf.useSsl() ? zConf.getServerSslPort() : zConf.getServerPort();
+    if (!expectedScheme.equals(origin.getScheme().toLowerCase(Locale.ROOT))
+        || effectivePort(origin) != expectedPort) {
+      return false;
+    }
+
+    String sourceUriHost = origin.getHost().toLowerCase(Locale.ROOT);
+    String currentHost = InetAddress.getLocalHost().getHostName().toLowerCase(Locale.ROOT);
+    return currentHost.equals(sourceUriHost)
         || "localhost".equals(sourceUriHost)
-        || zConf.getAllowedOrigins().contains(normalizedOrigin);
+        || "127.0.0.1".equals(sourceUriHost)
+        || "[::1]".equals(sourceUriHost)
+        || "::1".equals(sourceUriHost);
+  }
+
+  private static URI parseOrigin(String value) throws URISyntaxException {
+    URI origin = new URI(value);
+    String scheme = origin.getScheme();
+    if (scheme == null
+        || (!("http".equalsIgnoreCase(scheme)) && !("https".equalsIgnoreCase(scheme)))
+        || origin.getHost() == null
+        || origin.getUserInfo() != null
+        || (origin.getRawPath() != null && !origin.getRawPath().isEmpty())
+        || origin.getRawQuery() != null
+        || origin.getRawFragment() != null) {
+      throw new URISyntaxException(value, "Expected an HTTP Origin without path or credentials");
+    }
+    return origin;
+  }
+
+  private static String canonicalOrigin(URI origin) throws URISyntaxException {
+    String scheme = origin.getScheme().toLowerCase(Locale.ROOT);
+    int port = effectivePort(origin);
+    int canonicalPort = ("http".equals(scheme) && port == 80)
+        || ("https".equals(scheme) && port == 443) ? -1 : port;
+    return new URI(
+        scheme,
+        null,
+        origin.getHost().toLowerCase(Locale.ROOT),
+        canonicalPort,
+        null,
+        null,
+        null).toASCIIString();
+  }
+
+  private static int effectivePort(URI origin) {
+    if (origin.getPort() >= 0) {
+      return origin.getPort();
+    }
+    return "https".equalsIgnoreCase(origin.getScheme()) ? 443 : 80;
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/realm/kerberos/KerberosRealmTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/realm/kerberos/KerberosRealmTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.realm.kerberos;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.shiro.subject.Subject;
+import org.junit.jupiter.api.Test;
+
+class KerberosRealmTest {
+
+  @Test
+  void sameAuthenticatedPrincipalDoesNotRotateTheSession() {
+    KerberosRealm realm = new KerberosRealm();
+    Subject subject = mock(Subject.class);
+    when(subject.isAuthenticated()).thenReturn(true);
+    when(subject.getPrincipal()).thenReturn("user@example.com");
+    KerberosToken token = new KerberosToken("user@example.com", "signed-token");
+
+    realm.loginIfNecessary(subject, token);
+
+    verify(subject, never()).login(token);
+  }
+
+  @Test
+  void unauthenticatedSubjectLogsIn() {
+    KerberosRealm realm = new KerberosRealm();
+    Subject subject = mock(Subject.class);
+    KerberosToken token = new KerberosToken("user@example.com", "signed-token");
+
+    realm.loginIfNecessary(subject, token);
+
+    verify(subject).login(token);
+  }
+
+  @Test
+  void differentAuthenticatedPrincipalLogsIn() {
+    KerberosRealm realm = new KerberosRealm();
+    Subject subject = mock(Subject.class);
+    when(subject.isAuthenticated()).thenReturn(true);
+    when(subject.getPrincipal()).thenReturn("other@example.com");
+    KerberosToken token = new KerberosToken("user@example.com", "signed-token");
+
+    realm.loginIfNecessary(subject, token);
+
+    verify(subject).login(token);
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractRestApiTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.apache.zeppelin.service.AuthenticatedIdentity;
+import org.apache.zeppelin.service.AuthenticationService;
+import org.apache.zeppelin.service.ServiceContext;
+import org.junit.jupiter.api.Test;
+
+class AbstractRestApiTest {
+
+  @Test
+  void createsServiceContextFromOneIdentitySnapshot() {
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    AuthenticatedIdentity identity =
+        new AuthenticatedIdentity("user", Set.of("reader"), true, "session-id");
+    when(authenticationService.getAuthenticatedIdentity()).thenReturn(identity);
+
+    TestRestApi restApi = new TestRestApi(authenticationService);
+    ServiceContext context = restApi.exposeServiceContext();
+
+    assertEquals("user", context.getAutheInfo().getUser());
+    assertEquals(Set.of("reader"), context.getAutheInfo().getRoles());
+    assertNull(context.getAutheInfo().getTicket());
+    assertEquals(Set.of("user", "reader"), context.getUserAndRoles());
+    verify(authenticationService).getAuthenticatedIdentity();
+    verifyNoMoreInteractions(authenticationService);
+  }
+
+  private static class TestRestApi extends AbstractRestApi {
+
+    TestRestApi(AuthenticationService authenticationService) {
+      super(authenticationService);
+    }
+
+    ServiceContext exposeServiceContext() {
+      return getServiceContext();
+    }
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -134,6 +134,15 @@ public abstract class AbstractTestRestApi {
     return "http://localhost:" + zConf.getServerPort() + REST_API_URL;
   }
 
+  protected static String getOriginToTest(ZeppelinConfiguration zConf) {
+    for (String allowedOrigin : zConf.getAllowedOrigins()) {
+      if (!"*".equals(allowedOrigin)) {
+        return allowedOrigin;
+      }
+    }
+    return "http://localhost:" + zConf.getServerPort();
+  }
+
   public CloseableHttpResponse httpGet(String path)
       throws IOException {
     return httpGet(path, StringUtils.EMPTY, StringUtils.EMPTY);
@@ -148,7 +157,7 @@ public abstract class AbstractTestRestApi {
     throws IOException {
     LOGGER.info("Connecting to {}", getUrlToTest(zConf) + path);
     HttpGet httpGet = new HttpGet(getUrlToTest(zConf) + path);
-    httpGet.addHeader("Origin", getUrlToTest(zConf));
+    httpGet.addHeader("Origin", getOriginToTest(zConf));
     if (userAndPasswordAreNotBlank(user, pwd)) {
       httpGet.setHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
     }
@@ -169,7 +178,7 @@ public abstract class AbstractTestRestApi {
       throws IOException {
     LOGGER.info("Connecting to {}", getUrlToTest(zConf) + path);
     HttpDelete httpDelete = new HttpDelete(getUrlToTest(zConf) + path);
-    httpDelete.addHeader("Origin", getUrlToTest(zConf));
+    httpDelete.addHeader("Origin", getOriginToTest(zConf));
     if (userAndPasswordAreNotBlank(user, pwd)) {
       httpDelete.setHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
     }
@@ -210,7 +219,7 @@ public abstract class AbstractTestRestApi {
       throws IOException {
     LOGGER.info("Connecting to {}", getUrlToTest(zConf) + path);
     HttpPut httpPut = new HttpPut(getUrlToTest(zConf) + path);
-    httpPut.addHeader("Origin", getUrlToTest(zConf));
+    httpPut.addHeader("Origin", getOriginToTest(zConf));
     httpPut.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
     if (userAndPasswordAreNotBlank(user, pwd)) {
       httpPut.setHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
@@ -223,7 +232,7 @@ public abstract class AbstractTestRestApi {
   private String getCookie(String user, String password)
       throws IOException {
     HttpPost httpPost = new HttpPost(getUrlToTest(zConf) + "/login");
-    httpPost.addHeader("Origin", getUrlToTest(zConf));
+    httpPost.addHeader("Origin", getOriginToTest(zConf));
     ArrayList<NameValuePair> postParameters = new ArrayList<NameValuePair>();
     postParameters.add(new BasicNameValuePair("password", password));
     postParameters.add(new BasicNameValuePair("userName", user));

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/LoginRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/LoginRestApiTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.subject.Subject;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.AuthorizationService;
+import org.apache.zeppelin.service.AuthenticationService;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class LoginRestApiTest {
+
+  @Test
+  void reloginLogsOutBeforeLoginAndCreatesTheFinalSessionAfterLogin() {
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    when(authenticationService.getPrincipal()).thenReturn("user1");
+    when(authenticationService.getAssociatedRoles()).thenReturn(Set.of("role1"));
+    AuthorizationService authorizationService = mock(AuthorizationService.class);
+    LoginRestApi loginRestApi = new LoginRestApi(
+        mock(ZeppelinConfiguration.class),
+        authenticationService,
+        authorizationService);
+    Subject subject = mock(Subject.class);
+    UsernamePasswordToken token = new UsernamePasswordToken("user1", "password");
+
+    loginRestApi.proceedToLogin(subject, token);
+
+    InOrder order = inOrder(subject);
+    order.verify(subject).logout();
+    order.verify(subject).login(token);
+    order.verify(subject).getSession(true);
+    org.mockito.Mockito.verify(authorizationService).setRoles("user1", Set.of("role1"));
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
@@ -96,7 +96,7 @@ class SecurityRestApiTest extends AbstractTestRestApi {
 
     try {
       HttpPost login = new HttpPost(getUrlToTest(zConf) + "/login");
-      login.addHeader("Origin", getUrlToTest(zConf));
+      login.addHeader("Origin", getOriginToTest(zConf));
       List<NameValuePair> parameters = new ArrayList<>();
       parameters.add(new BasicNameValuePair("password", "password2"));
       parameters.add(new BasicNameValuePair("userName", principal));

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/server/CorsFilterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/server/CorsFilterTest.java
@@ -50,7 +50,7 @@ class CorsFilterTest {
 
   @Test
   void validCorsFilterTest() throws IOException, ServletException {
-    CorsFilter filter = new CorsFilter(ZeppelinConfiguration.load());
+    CorsFilter filter = new CorsFilter(defaultConfiguration());
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     FilterChain mockedFilterChain = mock(FilterChain.class);
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
@@ -65,7 +65,7 @@ class CorsFilterTest {
 
   @Test
   void invalidCorsFilterTest() throws IOException, ServletException {
-    CorsFilter filter = new CorsFilter(ZeppelinConfiguration.load());
+    CorsFilter filter = new CorsFilter(defaultConfiguration());
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     FilterChain mockedFilterChain = mock(FilterChain.class);
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
@@ -81,7 +81,7 @@ class CorsFilterTest {
   @ParameterizedTest
   @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH"})
   void crossOriginStateChangingBlocked(String method) throws IOException, ServletException {
-    CorsFilter filter = new CorsFilter(ZeppelinConfiguration.load());
+    CorsFilter filter = new CorsFilter(defaultConfiguration());
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     FilterChain mockedFilterChain = mock(FilterChain.class);
@@ -96,7 +96,7 @@ class CorsFilterTest {
 
   @Test
   void crossOriginPreflightBlocked() throws IOException, ServletException {
-    CorsFilter filter = new CorsFilter(ZeppelinConfiguration.load());
+    CorsFilter filter = new CorsFilter(defaultConfiguration());
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     FilterChain mockedFilterChain = mock(FilterChain.class);
@@ -112,11 +112,11 @@ class CorsFilterTest {
 
   @Test
   void allowedOriginPostPasses() throws IOException, ServletException {
-    CorsFilter filter = new CorsFilter(ZeppelinConfiguration.load());
+    CorsFilter filter = new CorsFilter(defaultConfiguration());
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     FilterChain mockedFilterChain = mock(FilterChain.class);
-    when(mockRequest.getHeader("Origin")).thenReturn("http://localhost");
+    when(mockRequest.getHeader("Origin")).thenReturn("http://localhost:8080");
     when(mockRequest.getMethod()).thenReturn("POST");
     Map<String, String> setHeaders = recordSetHeaders(mockResponse);
 
@@ -124,13 +124,13 @@ class CorsFilterTest {
 
     verify(mockResponse, never()).sendError(anyInt(), anyString());
     verify(mockedFilterChain, times(1)).doFilter(mockRequest, mockResponse);
-    assertEquals("http://localhost", setHeaders.get("Access-Control-Allow-Origin"));
+    assertEquals("http://localhost:8080", setHeaders.get("Access-Control-Allow-Origin"));
     assertEquals("true", setHeaders.get("Access-Control-Allow-Credentials"));
   }
 
   @Test
   void disallowedOriginGetPasses() throws IOException, ServletException {
-    CorsFilter filter = new CorsFilter(ZeppelinConfiguration.load());
+    CorsFilter filter = new CorsFilter(defaultConfiguration());
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     FilterChain mockedFilterChain = mock(FilterChain.class);
@@ -148,7 +148,7 @@ class CorsFilterTest {
 
   @Test
   void noOriginPostPasses() throws IOException, ServletException {
-    CorsFilter filter = new CorsFilter(ZeppelinConfiguration.load());
+    CorsFilter filter = new CorsFilter(defaultConfiguration());
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     FilterChain mockedFilterChain = mock(FilterChain.class);
@@ -163,7 +163,7 @@ class CorsFilterTest {
 
   @Test
   void simpleOptionsWithoutPreflightHeaderPasses() throws IOException, ServletException {
-    CorsFilter filter = new CorsFilter(ZeppelinConfiguration.load());
+    CorsFilter filter = new CorsFilter(defaultConfiguration());
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
     HttpServletResponse mockResponse = mock(HttpServletResponse.class);
     FilterChain mockedFilterChain = mock(FilterChain.class);
@@ -184,5 +184,9 @@ class CorsFilterTest {
       return null;
     }).when(response).setHeader(anyString(), anyString());
     return recorded;
+  }
+
+  private static ZeppelinConfiguration defaultConfiguration() {
+    return ZeppelinConfiguration.load("zeppelin-site.xml");
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/server/FailClosedShiroFilterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/server/FailClosedShiroFilterTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.web.filter.mgt.DefaultFilterChainManager;
+import org.apache.shiro.web.filter.mgt.FilterChainResolver;
+import org.apache.shiro.web.filter.mgt.NamedFilterList;
+import org.apache.shiro.web.filter.mgt.PathMatchingFilterChainResolver;
+import org.junit.jupiter.api.Test;
+
+class FailClosedShiroFilterTest {
+
+  @Test
+  void removingImplicitDefaultChainPreservesExplicitFirstMatchOrder() {
+    Ini ini = new Ini();
+    Ini.Section urls = ini.addSection("urls");
+    urls.put("/api/**", "authc");
+    urls.put("/api/version", "anon");
+    PathMatchingFilterChainResolver resolver = new PathMatchingFilterChainResolver();
+    DefaultFilterChainManager manager =
+        (DefaultFilterChainManager) resolver.getFilterChainManager();
+    manager.setGlobalFilters(List.of("invalidRequest"));
+    urls.forEach(manager::createChain);
+    manager.createDefaultChain("/**");
+
+    FailClosedShiroFilter.removeImplicitDefaultChain(ini, resolver);
+
+    assertEquals(List.of("/api/**", "/api/version"), List.copyOf(manager.getChainNames()));
+  }
+
+  @Test
+  void removingImplicitDefaultChainPreservesGlobalFiltersOnExplicitChains() {
+    Ini ini = new Ini();
+    ini.addSection("urls").put("/ws", "anon");
+    PathMatchingFilterChainResolver resolver = new PathMatchingFilterChainResolver();
+    DefaultFilterChainManager manager =
+        (DefaultFilterChainManager) resolver.getFilterChainManager();
+    manager.setGlobalFilters(List.of("invalidRequest"));
+    manager.createChain("/ws", "anon");
+    manager.createDefaultChain("/**");
+    NamedFilterList explicitChain = manager.getFilterChains().get("/ws");
+
+    FailClosedShiroFilter.removeImplicitDefaultChain(ini, resolver);
+
+    assertSame(explicitChain, manager.getFilterChains().get("/ws"));
+    assertEquals(2, explicitChain.size());
+    assertSame(manager.getFilter("invalidRequest"), explicitChain.get(0));
+    assertSame(manager.getFilter("anon"), explicitChain.get(1));
+  }
+
+  @Test
+  void explicitlyConfiguredCatchAllChainIsPreserved() {
+    Ini ini = new Ini();
+    ini.addSection("urls").put("/**", "authc");
+    PathMatchingFilterChainResolver resolver = new PathMatchingFilterChainResolver();
+    DefaultFilterChainManager manager =
+        (DefaultFilterChainManager) resolver.getFilterChainManager();
+    manager.createChain("/**", "authc");
+
+    FailClosedShiroFilter.removeImplicitDefaultChain(ini, resolver);
+
+    assertTrue(manager.getChainNames().contains("/**"));
+  }
+
+  @Test
+  void explicitAnonymousUrlChainContinuesRequest() throws IOException, ServletException {
+    FailClosedShiroFilter filter = new FailClosedShiroFilter();
+    PathMatchingFilterChainResolver resolver = new PathMatchingFilterChainResolver();
+    resolver.getFilterChainManager().createChain("/ws", "anon");
+    FilterChain originalChain = mock(FilterChain.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    filter.setFilterChainResolver(resolver);
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/ws");
+    when(request.getServletPath()).thenReturn("/ws");
+
+    FilterChain anonymousChain = filter.getExecutionChain(request, response, originalChain);
+    anonymousChain.doFilter(request, response);
+
+    verify(originalChain).doFilter(request, response);
+    verify(response, never()).sendError(eq(HttpServletResponse.SC_FORBIDDEN), anyString());
+  }
+
+  @Test
+  void missingUrlChainIsRejected() throws IOException, ServletException {
+    FailClosedShiroFilter filter = new FailClosedShiroFilter();
+    FilterChainResolver resolver = mock(FilterChainResolver.class);
+    FilterChain originalChain = mock(FilterChain.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    filter.setFilterChainResolver(resolver);
+    when(resolver.getChain(request, response, originalChain)).thenReturn(null);
+
+    FilterChain deniedChain = filter.getExecutionChain(request, response, originalChain);
+    deniedChain.doFilter(request, response);
+
+    verify(response).sendError(eq(HttpServletResponse.SC_FORBIDDEN), anyString());
+    verify(originalChain, never()).doFilter(request, response);
+  }
+
+  @Test
+  void missingResolverIsRejected() throws IOException, ServletException {
+    FailClosedShiroFilter filter = new FailClosedShiroFilter();
+    FilterChain originalChain = mock(FilterChain.class);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    FilterChain deniedChain = filter.getExecutionChain(request, response, originalChain);
+    deniedChain.doFilter(request, response);
+
+    verify(response).sendError(eq(HttpServletResponse.SC_FORBIDDEN), anyString());
+    verify(originalChain, never()).doFilter(request, response);
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/server/ShiroIniTemplateTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/server/ShiroIniTemplateTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.web.config.WebIniSecurityManagerFactory;
+import org.junit.jupiter.api.Test;
+
+class ShiroIniTemplateTest {
+
+  @Test
+  void templateUsesUnifiedUrlPolicyAndLoadsWithCurrentShiro() {
+    Path template = findTemplate("shiro.ini.template");
+    Ini ini = Ini.fromResourcePath(template.toUri().toString());
+    Ini.Section urls = ini.getSection("urls");
+    assertEquals("authc", urls.get("/ws"));
+    assertEquals("authc", urls.get("/**"));
+    List<String> orderedPaths = List.copyOf(urls.keySet());
+    assertTrue(orderedPaths.indexOf("/ws") < orderedPaths.indexOf("/**"));
+
+    WebIniSecurityManagerFactory factory = new WebIniSecurityManagerFactory(ini);
+    try {
+      SecurityManager securityManager = factory.getInstance();
+      assertTrue(securityManager != null);
+    } finally {
+      factory.destroy();
+    }
+  }
+
+  @Test
+  void zeppelinSiteTemplateDoesNotEnableWildcardOrigins() throws Exception {
+    String template = Files.readString(findTemplate("zeppelin-site.xml.template"));
+    Pattern allowedOrigins = Pattern.compile(
+        "<name>zeppelin\\.server\\.allowed\\.origins</name>\\s*<value>\\s*</value>");
+
+    assertTrue(allowedOrigins.matcher(template).find());
+  }
+
+  private static Path findTemplate(String fileName) {
+    Path workingDirectory = Path.of(System.getProperty("user.dir"));
+    Path template = workingDirectory.resolve("conf").resolve(fileName);
+    if (!Files.exists(template)) {
+      template = workingDirectory.resolve("../conf").resolve(fileName).normalize();
+    }
+    assertTrue(Files.exists(template), "Cannot find conf/" + fileName);
+    return template;
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/AuthenticatedSessionServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/AuthenticatedSessionServiceTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.lang.util.LifecycleUtils;
+import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.realm.SimpleAccountRealm;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
+import org.apache.zeppelin.service.AuthenticatedSessionService.SessionAuthenticationException;
+import org.junit.jupiter.api.Test;
+
+class AuthenticatedSessionServiceTest {
+
+  @Test
+  void identityIsImmutableAndNoAuthenticationUsesTheSharedAnonymousIdentity() {
+    Set<String> roles = new HashSet<>();
+    roles.add("reader");
+    AuthenticatedIdentity identity =
+        new AuthenticatedIdentity("user", roles, true, "session-id");
+
+    roles.add("admin");
+
+    assertEquals(Set.of("reader"), identity.getRoles());
+    assertThrows(UnsupportedOperationException.class, () -> identity.getRoles().add("writer"));
+    assertTrue(identity.isAuthenticated());
+    assertEquals("session-id", identity.getSessionId().orElseThrow());
+
+    AuthenticatedIdentity anonymous = new NoAuthenticationService().getAuthenticatedIdentity();
+    assertSame(AuthenticatedIdentity.anonymous(), anonymous);
+    assertFalse(anonymous.isAuthenticated());
+    assertTrue(anonymous.getSessionId().isEmpty());
+  }
+
+  @Test
+  void anonymousIdentityNeedsNoSessionOrAuthenticationManager() {
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    AuthenticatedSessionService service =
+        new AuthenticatedSessionService(() -> authenticationService);
+
+    assertSame(
+        AuthenticatedIdentity.anonymous(),
+        service.refresh(AuthenticatedIdentity.anonymous(), null, true));
+    service.validate(AuthenticatedIdentity.anonymous(), null);
+
+    verify(authenticationService, never()).getAuthenticatedIdentity();
+    verify(authenticationService, never()).getPrincipal();
+  }
+
+  @Test
+  void refreshesIdentityAndTouchesRealClientOperations() throws Exception {
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    AuthenticatedIdentity captured = identity("user1", "role1", "session-id");
+    AuthenticatedIdentity refreshed = identity("user1", "role2", "session-id");
+    when(authenticationService.getAuthenticatedIdentity()).thenReturn(refreshed);
+    Session session = session("session-id");
+    Subject subject = authenticatedSubject(session);
+    AuthenticatedSessionService service =
+        spy(new AuthenticatedSessionService(() -> authenticationService));
+    SecurityManager securityManager = mock(SecurityManager.class);
+    doReturn(subject).when(service).restoreSubject("session-id", securityManager);
+
+    assertSame(refreshed, service.refresh(captured, securityManager, true));
+
+    verify(session).touch();
+  }
+
+  @Test
+  void pingRefreshDoesNotExtendIdleTimeout() throws Exception {
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    AuthenticatedIdentity identity = identity("user1", "role1", "session-id");
+    when(authenticationService.getAuthenticatedIdentity()).thenReturn(identity);
+    Session session = session("session-id");
+    Subject subject = authenticatedSubject(session);
+    AuthenticatedSessionService service =
+        spy(new AuthenticatedSessionService(() -> authenticationService));
+    SecurityManager securityManager = mock(SecurityManager.class);
+    doReturn(subject).when(service).restoreSubject("session-id", securityManager);
+
+    assertSame(identity, service.refresh(identity, securityManager, false));
+
+    verify(session, never()).touch();
+  }
+
+  @Test
+  void validateChecksPrincipalWithoutResolvingRolesOrTouchingSession() throws Exception {
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    AuthenticatedIdentity identity = identity("user1", "role1", "session-id");
+    when(authenticationService.getPrincipal()).thenReturn("user1");
+    Session session = session("session-id");
+    Subject subject = authenticatedSubject(session);
+    AuthenticatedSessionService service =
+        spy(new AuthenticatedSessionService(() -> authenticationService));
+    SecurityManager securityManager = mock(SecurityManager.class);
+    doReturn(subject).when(service).restoreSubject("session-id", securityManager);
+
+    service.validate(identity, securityManager);
+
+    verify(authenticationService).getPrincipal();
+    verify(authenticationService, never()).getAuthenticatedIdentity();
+    verify(session, never()).touch();
+  }
+
+  @Test
+  void resolvesAuthenticationServiceInCapturedContextAndRestoresCallerContext() {
+    Map<Object, Object> previousResources = ThreadContext.getResources();
+    ThreadContext.remove();
+
+    SimpleAccountRealm realm = new SimpleAccountRealm();
+    realm.addAccount("user1", "password");
+    DefaultSecurityManager capturedManager = new DefaultSecurityManager(realm);
+    DefaultSecurityManager callerManager = new DefaultSecurityManager();
+    try {
+      Subject loginSubject = new Subject.Builder(capturedManager).buildSubject();
+      loginSubject.getSession();
+      loginSubject.login(new UsernamePasswordToken("user1", "password"));
+      Serializable sessionId = loginSubject.getSession(false).getId();
+
+      AuthenticationService authenticationService = mock(AuthenticationService.class);
+      when(authenticationService.getPrincipal()).thenReturn("user1");
+      AtomicReference<Subject> restoredSubject = new AtomicReference<>();
+      AtomicReference<Subject> providerSubject = new AtomicReference<>();
+      AtomicReference<SecurityManager> providerManager = new AtomicReference<>();
+      AuthenticatedSessionService service =
+          new AuthenticatedSessionService(() -> {
+            providerSubject.set(ThreadContext.getSubject());
+            providerManager.set(ThreadContext.getSecurityManager());
+            return authenticationService;
+          }) {
+            @Override
+            Subject restoreSubject(
+                Serializable requestedSessionId, SecurityManager securityManager) {
+              Subject subject = super.restoreSubject(requestedSessionId, securityManager);
+              restoredSubject.set(subject);
+              return subject;
+            }
+          };
+
+      Subject callerSubject = new Subject.Builder(callerManager).buildSubject();
+      Object callerResource = new Object();
+      ThreadContext.bind(callerManager);
+      ThreadContext.bind(callerSubject);
+      ThreadContext.put("caller-resource", callerResource);
+
+      service.validate(
+          new AuthenticatedIdentity("user1", Set.of("role1"), true, sessionId),
+          capturedManager);
+
+      assertSame(capturedManager, providerManager.get());
+      assertSame(restoredSubject.get(), providerSubject.get());
+      assertEquals(sessionId, providerSubject.get().getSession(false).getId());
+      assertSame(callerManager, ThreadContext.getSecurityManager());
+      assertSame(callerSubject, ThreadContext.getSubject());
+      assertSame(callerResource, ThreadContext.get("caller-resource"));
+    } finally {
+      ThreadContext.remove();
+      LifecycleUtils.destroy(callerManager);
+      LifecycleUtils.destroy(capturedManager);
+      if (!previousResources.isEmpty()) {
+        ThreadContext.setResources(previousResources);
+      }
+    }
+  }
+
+  @Test
+  void rejectsChangedPrincipal() throws Exception {
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    AuthenticatedIdentity captured = identity("user1", "role1", "session-id");
+    when(authenticationService.getAuthenticatedIdentity())
+        .thenReturn(identity("user2", "role1", "session-id"));
+    Subject subject = authenticatedSubject(session("session-id"));
+    AuthenticatedSessionService service =
+        spy(new AuthenticatedSessionService(() -> authenticationService));
+    SecurityManager securityManager = mock(SecurityManager.class);
+    doReturn(subject).when(service).restoreSubject("session-id", securityManager);
+
+    assertThrows(
+        SessionAuthenticationException.class,
+        () -> service.refresh(captured, securityManager, true));
+  }
+
+  @Test
+  void rejectsMissingMismatchedOrUnauthenticatedSession() throws Exception {
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    AuthenticatedIdentity captured = identity("user1", "role1", "session-id");
+    Subject subject = mock(Subject.class);
+    when(subject.getSession(false)).thenReturn(null);
+    AuthenticatedSessionService service =
+        spy(new AuthenticatedSessionService(() -> authenticationService));
+    SecurityManager securityManager = mock(SecurityManager.class);
+    doReturn(subject).when(service).restoreSubject("session-id", securityManager);
+
+    assertThrows(
+        SessionAuthenticationException.class,
+        () -> service.refresh(captured, securityManager, false));
+
+    Subject mismatchedSubject = authenticatedSubject(session("another-session"));
+    doReturn(mismatchedSubject).when(service).restoreSubject("session-id", securityManager);
+    assertThrows(
+        SessionAuthenticationException.class,
+        () -> service.refresh(captured, securityManager, false));
+
+    Subject unauthenticatedSubject = mock(Subject.class);
+    Session exactSession = session("session-id");
+    when(unauthenticatedSubject.getSession(false)).thenReturn(exactSession);
+    doReturn(unauthenticatedSubject)
+        .when(service).restoreSubject("session-id", securityManager);
+    assertThrows(
+        SessionAuthenticationException.class,
+        () -> service.refresh(captured, securityManager, false));
+  }
+
+  @Test
+  void authenticatedIdentityRequiresTheExactAuthenticationManager() {
+    AuthenticatedSessionService service =
+        new AuthenticatedSessionService(() -> mock(AuthenticationService.class));
+
+    assertThrows(
+        SessionAuthenticationException.class,
+        () -> service.validate(identity("user1", "role1", "session-id"), null));
+  }
+
+  private static AuthenticatedIdentity identity(
+      String principal, String role, String sessionId) {
+    return new AuthenticatedIdentity(principal, Set.of(role), true, sessionId);
+  }
+
+  private static Session session(String id) {
+    Session session = mock(Session.class);
+    when(session.getId()).thenReturn(id);
+    return session;
+  }
+
+  private static Subject authenticatedSubject(Session session) throws Exception {
+    Subject subject = mock(Subject.class);
+    when(subject.getSession(false)).thenReturn(session);
+    when(subject.isAuthenticated()).thenReturn(true);
+    when(subject.execute(org.mockito.ArgumentMatchers.<Callable<?>>any()))
+        .thenAnswer(invocation -> ((Callable<?>) invocation.getArgument(0)).call());
+    return subject;
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -43,11 +43,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.common.Message;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.Interpreter.FormType;
@@ -175,6 +177,40 @@ class NotebookServiceTest {
       confDir.delete();
     }
     searchService.close();
+  }
+
+  @Test
+  void spellUsesTheAuthenticatedServiceContextInsteadOfMessageIdentity() throws IOException {
+    AuthenticationInfo authenticated =
+        new AuthenticationInfo("session-user", Set.of("role1"), null);
+    ServiceContext authenticatedContext = new ServiceContext(
+        authenticated, new HashSet<>(Set.of("session-user", "role1")));
+    String noteId = notebookService.createNote(
+        "/spell-auth", "test", true, authenticatedContext, callback);
+    String paragraphId = notebook.processNote(
+        noteId, note -> note.getParagraph(0).getId());
+    Message forged = new Message(Message.OP.PARAGRAPH_EXECUTED_BY_SPELL)
+        .put("id", paragraphId)
+        .put("paragraph", "%md result")
+        .put("title", "")
+        .put("status", "FINISHED")
+        .put("params", Map.of())
+        .put("config", Map.of())
+        .put("results", new InterpreterResult(Code.SUCCESS, "ok"))
+        .put("errorMessage", null)
+        .put("dateStarted", "2026-08-07T00:00:00.000Z")
+        .put("dateFinished", "2026-08-07T00:00:01.000Z");
+    forged.principal = "forged-admin";
+    forged.roles = "[\"admin\"]";
+    forged.ticket = "forged-ticket";
+
+    notebookService.spell(noteId, forged, authenticatedContext, callback);
+
+    AuthenticationInfo stored = notebook.processNote(
+        noteId, note -> note.getParagraph(paragraphId).getAuthenticationInfo());
+    assertEquals("session-user", stored.getUser());
+    assertEquals(Set.of("role1"), stored.getRoles());
+    assertNull(stored.getTicket());
   }
 
   @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
@@ -18,20 +18,26 @@ package org.apache.zeppelin.service;
 
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.security.Principal;
 import java.sql.Connection;
 import java.sql.Statement;
 import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.realm.jdbc.JdbcRealm;
+import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.lang.util.LifecycleUtils;
 import org.apache.shiro.util.ThreadContext;
@@ -100,6 +106,45 @@ class ShiroAuthenticationServiceTest extends AbstractShiroTest {
     when(zConf.isUsernameForceLowerCase()).thenReturn(true);
     setupPrincipalName(expectedName);
     assertEquals(expectedName.toLowerCase(), shiroSecurityService.getPrincipal());
+  }
+
+  @Test
+  void capturesPrincipalRolesAndSessionFromOneSubject() {
+    setupPrincipalName("TestUser");
+    when(zConf.isUsernameForceLowerCase()).thenReturn(true);
+    Session session = mock(Session.class);
+    when(session.getId()).thenReturn("session-id");
+    when(subject.getSession(false)).thenReturn(session);
+
+    KnoxJwtRealm realm = spy(new KnoxJwtRealm());
+    LifecycleUtils.init(realm);
+    when(realm.mapGroupPrincipals("testuser")).thenReturn(Set.of("reader"));
+    ThreadContext.bind(new DefaultSecurityManager(realm));
+
+    AuthenticatedIdentity identity = shiroSecurityService.getAuthenticatedIdentity();
+
+    assertEquals("testuser", identity.getPrincipal());
+    assertEquals(Set.of("reader"), identity.getRoles());
+    assertEquals("session-id", identity.getSessionId().orElseThrow());
+    assertTrue(identity.isAuthenticated());
+    verify(subject, times(1)).isAuthenticated();
+    verify(subject, times(1)).getPrincipal();
+    verify(subject, times(1)).getSession(false);
+  }
+
+  @Test
+  void capturesAnonymousIdentityWithoutLookingUpSession() {
+    when(subject.isAuthenticated()).thenReturn(false);
+
+    AuthenticatedIdentity identity = shiroSecurityService.getAuthenticatedIdentity();
+
+    assertEquals(AuthenticatedIdentity.ANONYMOUS_PRINCIPAL, identity.getPrincipal());
+    assertEquals(Collections.emptySet(), identity.getRoles());
+    assertFalse(identity.isAuthenticated());
+    assertTrue(identity.getSessionId().isEmpty());
+    verify(subject, times(1)).isAuthenticated();
+    verify(subject, times(0)).getPrincipal();
+    verify(subject, times(0)).getSession(false);
   }
 
   @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/ExpiredWebSocketAuthenticationTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/ExpiredWebSocketAuthenticationTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.http.Header;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.zeppelin.MiniZeppelinServer;
+import org.apache.zeppelin.common.Message;
+import org.apache.zeppelin.common.Message.OP;
+import org.apache.zeppelin.rest.AbstractTestRestApi;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExpiredWebSocketAuthenticationTest extends AbstractTestRestApi {
+
+  private static final long SESSION_TIMEOUT_MILLIS = 1000;
+
+  private static MiniZeppelinServer zepServer;
+  private static WebSocketClient webSocketClient;
+
+  @BeforeAll
+  static void startServer() throws Exception {
+    zepServer = new MiniZeppelinServer(
+        ExpiredWebSocketAuthenticationTest.class.getSimpleName());
+    zepServer.addConfigFile(
+        "shiro.ini", ZEPPELIN_SHIRO.replace("86400000", "1000"));
+    zepServer.start();
+    zepServer.getZeppelinConfiguration().setProperty(
+        org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_ALLOWED_ORIGINS
+            .getVarName(),
+        "http://localhost:" + zepServer.getZeppelinConfiguration().getServerPort());
+    webSocketClient = new WebSocketClient();
+    webSocketClient.start();
+  }
+
+  @AfterAll
+  static void stopServer() throws Exception {
+    if (webSocketClient != null) {
+      webSocketClient.stop();
+    }
+    if (zepServer != null) {
+      zepServer.destroy();
+    }
+  }
+
+  @BeforeEach
+  void setUpConfiguration() {
+    zConf = zepServer.getZeppelinConfiguration();
+  }
+
+  @Test
+  void expiredSessionClosesBeforeInboundDispatch() throws Exception {
+    String cookie = login();
+    TestSocket socket = new TestSocket();
+    Session session = connect(socket, cookie).get(10, TimeUnit.SECONDS);
+
+    awaitSessionExpiration();
+    session.getRemote().sendString(new Message(OP.LIST_NOTES).toJson());
+
+    assertEquals(1008, socket.awaitCloseCode());
+  }
+
+  @Test
+  void expiredSessionClosesBeforeOutboundDelivery() throws Exception {
+    String cookie = login();
+    TestSocket socket = new TestSocket();
+    connect(socket, cookie).get(10, TimeUnit.SECONDS);
+
+    awaitSessionExpiration();
+    zepServer.getService(ConnectionManager.class).broadcast(new Message(OP.NOTES_INFO));
+
+    assertEquals(1008, socket.awaitCloseCode());
+  }
+
+  private String login() throws Exception {
+    HttpPost login = new HttpPost(
+        "http://localhost:" + zConf.getServerPort() + "/api/login");
+    login.setHeader("Origin", validOrigin());
+    login.setEntity(new UrlEncodedFormEntity(List.of(
+        new BasicNameValuePair("userName", "user1"),
+        new BasicNameValuePair("password", "password2")), StandardCharsets.UTF_8));
+    try (CloseableHttpClient client = HttpClients.custom()
+             .disableCookieManagement()
+             .disableRedirectHandling()
+             .build();
+         CloseableHttpResponse response = client.execute(login)) {
+      assertEquals(200, response.getStatusLine().getStatusCode());
+      return sessionCookie(response);
+    }
+  }
+
+  private CompletableFuture<Session> connect(TestSocket socket, String sessionCookie)
+      throws Exception {
+    ClientUpgradeRequest request = new ClientUpgradeRequest();
+    request.setHeader("Origin", validOrigin());
+    request.setHeader("Cookie", "JSESSIONID=" + sessionCookie);
+    return webSocketClient.connect(socket, websocketUri(), request);
+  }
+
+  private static String sessionCookie(CloseableHttpResponse response) {
+    Pattern pattern = Pattern.compile("JSESSIONID=([a-zA-Z0-9-]+)");
+    for (Header header : response.getHeaders("Set-Cookie")) {
+      Matcher matcher = pattern.matcher(header.getValue());
+      if (matcher.find() && !header.getValue().contains("Max-Age=0")) {
+        return matcher.group(1);
+      }
+    }
+    throw new AssertionError("Login did not issue a JSESSIONID cookie");
+  }
+
+  private static void awaitSessionExpiration() throws InterruptedException {
+    Thread.sleep(SESSION_TIMEOUT_MILLIS + 300);
+  }
+
+  private URI websocketUri() {
+    return URI.create("ws://localhost:" + zConf.getServerPort() + "/ws");
+  }
+
+  private String validOrigin() {
+    return "http://localhost:" + zConf.getServerPort();
+  }
+
+  private static final class TestSocket extends WebSocketAdapter {
+    private final CompletableFuture<Integer> closeCode = new CompletableFuture<>();
+
+    @Override
+    public void onWebSocketClose(int statusCode, String reason) {
+      closeCode.complete(statusCode);
+      super.onWebSocketClose(statusCode, reason);
+    }
+
+    int awaitCloseCode() throws Exception {
+      return closeCode.get(10, TimeUnit.SECONDS);
+    }
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerAuthenticationTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerAuthenticationTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpointConfig;
+
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.zeppelin.common.Message;
+import org.apache.zeppelin.common.Message.OP;
+import org.apache.zeppelin.service.AuthenticatedIdentity;
+import org.apache.zeppelin.service.AuthenticatedSessionService;
+import org.apache.zeppelin.service.NotebookService;
+import org.apache.zeppelin.service.ServiceContext;
+import org.apache.zeppelin.service.AuthenticatedSessionService.SessionAuthenticationException;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class NotebookServerAuthenticationTest {
+
+  @Test
+  void missingHandshakeIdentityFailsClosedBeforeSessionLookup() throws Exception {
+    AuthenticatedSessionService sessionService = mock(AuthenticatedSessionService.class);
+    ConnectionManager connectionManager = mock(ConnectionManager.class);
+    NotebookServer server = server(
+        sessionService, mock(NotebookService.class), connectionManager);
+    Session session = mock(Session.class);
+    ServerEndpointConfig endpointConfig = ServerEndpointConfig.Builder
+        .create(NotebookServer.class, "/ws")
+        .build();
+
+    server.onOpen(session, endpointConfig);
+
+    ArgumentCaptor<CloseReason> closeReason = ArgumentCaptor.forClass(CloseReason.class);
+    verify(session).close(closeReason.capture());
+    assertEquals(CloseReason.CloseCodes.VIOLATED_POLICY,
+        closeReason.getValue().getCloseCode());
+    verifyNoInteractions(sessionService, connectionManager);
+  }
+
+  @Test
+  void logoutBetweenHandshakeValidationAndRegistrationClosesTheSocket() throws Exception {
+    AuthenticatedIdentity identity =
+        new AuthenticatedIdentity("user1", Set.of(), true, "session-id");
+    SecurityManager securityManager = mock(SecurityManager.class);
+    AuthenticatedSessionService sessionService = mock(AuthenticatedSessionService.class);
+    when(sessionService.refresh(identity, securityManager, false)).thenReturn(identity);
+    doThrow(new SessionAuthenticationException("logged out"))
+        .when(sessionService).validate(identity, securityManager);
+    ConnectionManager connectionManager = mock(ConnectionManager.class);
+    NotebookServer server = server(sessionService, mock(NotebookService.class), connectionManager);
+    Session session = mock(Session.class);
+    when(session.getId()).thenReturn("websocket-id");
+    ServerEndpointConfig endpointConfig = ServerEndpointConfig.Builder
+        .create(NotebookServer.class, "/ws")
+        .build();
+    endpointConfig.getUserProperties().put(SessionConfigurator.AUTHENTICATED_IDENTITY, identity);
+    endpointConfig.getUserProperties().put(
+        SessionConfigurator.AUTHENTICATION_SECURITY_MANAGER, securityManager);
+
+    server.onOpen(session, endpointConfig);
+
+    verify(connectionManager).addUserConnection(eq("user1"), any(NotebookSocket.class));
+    verify(connectionManager).removeConnection(any(NotebookSocket.class));
+    verify(connectionManager).removeConnectionFromAllNote(any(NotebookSocket.class));
+    verify(connectionManager).removeUserConnection(anyString(), any(NotebookSocket.class));
+    ArgumentCaptor<CloseReason> closeReason = ArgumentCaptor.forClass(CloseReason.class);
+    verify(session).close(closeReason.capture());
+    assertEquals(CloseReason.CloseCodes.VIOLATED_POLICY,
+        closeReason.getValue().getCloseCode());
+  }
+
+  @Test
+  void clientIdentityFieldsCannotOverrideTheAuthenticatedSession() throws Exception {
+    AuthenticatedIdentity connectionIdentity =
+        new AuthenticatedIdentity("user1", Set.of("role1"), true, "session-id");
+    AuthenticatedIdentity refreshedIdentity =
+        new AuthenticatedIdentity("user1", Set.of("role2"), true, "session-id");
+    AuthenticatedSessionService sessionService = mock(AuthenticatedSessionService.class);
+    SecurityManager securityManager = mock(SecurityManager.class);
+    when(sessionService.refresh(connectionIdentity, securityManager, true))
+        .thenReturn(refreshedIdentity);
+    NotebookService notebookService = mock(NotebookService.class);
+    NotebookServer server = server(
+        sessionService, notebookService, mock(ConnectionManager.class));
+    NotebookSocket socket = authenticatedSocket(connectionIdentity, securityManager);
+
+    Message message = new Message(OP.LIST_NOTES);
+    message.principal = "admin";
+    message.roles = "[\"admin\"]";
+    message.ticket = "forged-ticket";
+    server.onMessage(socket, message.toJson());
+
+    ArgumentCaptor<ServiceContext> context = ArgumentCaptor.forClass(ServiceContext.class);
+    verify(notebookService).listNotesInfo(eq(false), context.capture(), any());
+    assertEquals("user1", context.getValue().getAutheInfo().getUser());
+    assertEquals(Set.of("role2"), context.getValue().getAutheInfo().getRoles());
+    assertNull(context.getValue().getAutheInfo().getTicket());
+  }
+
+  @Test
+  void invalidSessionClosesBeforeDispatch() throws Exception {
+    AuthenticatedIdentity identity =
+        new AuthenticatedIdentity("user1", Set.of(), true, "session-id");
+    AuthenticatedSessionService sessionService = mock(AuthenticatedSessionService.class);
+    SecurityManager securityManager = mock(SecurityManager.class);
+    when(sessionService.refresh(identity, securityManager, true))
+        .thenThrow(new SessionAuthenticationException("expired"));
+    NotebookService notebookService = mock(NotebookService.class);
+    NotebookServer server = server(
+        sessionService, notebookService, mock(ConnectionManager.class));
+    NotebookSocket socket = authenticatedSocket(identity, securityManager);
+
+    server.onMessage(socket, new Message(OP.LIST_NOTES).toJson());
+
+    ArgumentCaptor<CloseReason> closeReason = ArgumentCaptor.forClass(CloseReason.class);
+    verify(socket).close(closeReason.capture());
+    assertEquals(CloseReason.CloseCodes.VIOLATED_POLICY,
+        closeReason.getValue().getCloseCode());
+    verify(notebookService, never()).listNotesInfo(anyBoolean(), any(), any());
+    verify(socket, never()).send(any());
+  }
+
+  @Test
+  void pingRevalidatesWithoutTouchingTheSession() {
+    AuthenticatedIdentity identity =
+        new AuthenticatedIdentity("user1", Set.of(), true, "session-id");
+    AuthenticatedSessionService sessionService = mock(AuthenticatedSessionService.class);
+    SecurityManager securityManager = mock(SecurityManager.class);
+    NotebookServer server = server(
+        sessionService, mock(NotebookService.class), mock(ConnectionManager.class));
+    NotebookSocket socket = authenticatedSocket(identity, securityManager);
+
+    server.onMessage(socket, new Message(OP.PING).toJson());
+
+    verify(sessionService).validate(identity, securityManager);
+    verify(sessionService, never()).refresh(any(), any(), anyBoolean());
+  }
+
+  private static NotebookServer server(
+      AuthenticatedSessionService sessionService,
+      NotebookService notebookService,
+      ConnectionManager connectionManager) {
+    NotebookServer server = new NotebookServer();
+    server.setAuthenticatedSessionService(sessionService);
+    server.setNotebookService(() -> notebookService);
+    server.setConnectionManager(connectionManager);
+    return server;
+  }
+
+  private static NotebookSocket authenticatedSocket(
+      AuthenticatedIdentity identity, SecurityManager securityManager) {
+    NotebookSocket socket = mock(NotebookSocket.class);
+    when(socket.getAuthenticatedIdentity()).thenReturn(identity);
+    when(socket.getAuthenticationSecurityManager()).thenReturn(securityManager);
+    when(socket.getUser()).thenReturn(identity.getPrincipal());
+    return socket;
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerLoggingTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerLoggingTest.java
@@ -32,6 +32,7 @@ import org.apache.log4j.spi.LoggingEvent;
 import org.apache.zeppelin.common.Message;
 import org.apache.zeppelin.common.Message.OP;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.service.AuthenticatedIdentity;
 import org.apache.zeppelin.ticket.TicketContainer;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +52,8 @@ class NotebookServerLoggingTest {
     notebookServer.setZeppelinConfiguration(zConf);
     NotebookSocket conn = mock(NotebookSocket.class);
     when(conn.getUser()).thenReturn(principal);
+    when(conn.getAuthenticatedIdentity()).thenReturn(
+        new AuthenticatedIdentity(principal, Collections.emptySet(), false, null));
 
     Message message = new Message(OP.CONVERT_NOTE_NBFORMAT)
         .put("ticketCopy", ticket)

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -26,17 +26,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -70,6 +68,7 @@ import org.apache.zeppelin.common.Message.OP;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
+import org.apache.zeppelin.service.AuthenticatedIdentity;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -117,18 +116,6 @@ class NotebookServerTest extends AbstractTestRestApi {
   void setUp() {
     zConf = zepServer.getZeppelinConfiguration();
     anonymous = AuthenticationInfo.ANONYMOUS;
-  }
-
-  @Test
-  void checkOrigin() throws UnknownHostException {
-    String origin = "http://" + InetAddress.getLocalHost().getHostName() + ":8080";
-    assertTrue(notebookServer.checkOrigin(origin),
-      "Origin " + origin + " is not allowed. Please check your hostname.");
-  }
-
-  @Test
-  void checkInvalidOrigin() {
-    assertFalse(notebookServer.checkOrigin("http://evillocalhost:8080"));
   }
 
   @Test
@@ -321,8 +308,8 @@ class NotebookServerTest extends AbstractTestRestApi {
 
     int sock1SendCount = 0;
     int sock2SendCount = 0;
-    reset(sock1);
-    reset(sock2);
+    clearInvocations(sock1);
+    clearInvocations(sock2);
     patchParagraph(sock1, paragraphId, patches[0]);
     assertEquals("ABC", paragraph.getText());
     verify(sock1, times(sock1SendCount)).send(anyString());
@@ -410,8 +397,8 @@ class NotebookServerTest extends AbstractTestRestApi {
       notebookServer.onMessage(sock1, new Message(OP.GET_NOTE).put("id", note1Id).toJson());
       notebookServer.onMessage(sock2, new Message(OP.GET_NOTE).put("id", note1Id).toJson());
 
-      reset(sock1);
-      reset(sock2);
+      clearInvocations(sock1);
+      clearInvocations(sock2);
 
       // update object from sock1
       notebookServer.onMessage(sock1,
@@ -480,7 +467,7 @@ class NotebookServerTest extends AbstractTestRestApi {
       // open the same notebook from sockets
       notebookServer.onMessage(sock1, new Message(OP.GET_NOTE).put("id", note1Id).toJson());
 
-      reset(sock1);
+      clearInvocations(sock1);
 
       // bind object from sock1
       notebookServer.onMessage(sock1,
@@ -985,7 +972,7 @@ class NotebookServerTest extends AbstractTestRestApi {
       verify(socket).send(response.capture());
       assertEquals(OP.AUTH_INFO, notebookServer.deserializeMessage(response.getValue()).op);
 
-      reset(socket);
+      clearInvocations(socket);
       setNotePermissions(noteId, "binding-owner", "binding-reader");
       notebookServer.getInterpreterBindings(socket, serviceContext("binding-reader"), message);
 
@@ -1018,7 +1005,7 @@ class NotebookServerTest extends AbstractTestRestApi {
       verify(socket).send(response.capture());
       assertEquals(OP.AUTH_INFO, notebookServer.deserializeMessage(response.getValue()).op);
 
-      reset(socket);
+      clearInvocations(socket);
       authorizationService.setWriters(noteId,
           new HashSet<>(Arrays.asList("binding-owner", "binding-writer")));
       notebookServer.saveInterpreterBindings(socket, serviceContext("binding-writer"), message);
@@ -1088,6 +1075,7 @@ class NotebookServerTest extends AbstractTestRestApi {
 
   private NotebookSocket createWebSocket() {
     NotebookSocket sock = mock(NotebookSocket.class);
+    when(sock.getAuthenticatedIdentity()).thenReturn(AuthenticatedIdentity.anonymous());
     return sock;
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/SessionConfiguratorTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/SessionConfiguratorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.socket;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.websocket.HandshakeResponse;
+import jakarta.websocket.server.HandshakeRequest;
+import jakarta.websocket.server.ServerEndpointConfig;
+
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.util.ThreadContext;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.service.AuthenticatedIdentity;
+import org.apache.zeppelin.service.AuthenticationService;
+import org.apache.zeppelin.util.WatcherSecurityKey;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.junit.jupiter.api.Test;
+
+class SessionConfiguratorTest {
+
+  @Test
+  void rejectsInvalidOriginsBeforeTheEndpointIsOpened() {
+    ZeppelinConfiguration zConf = mock(ZeppelinConfiguration.class);
+    when(zConf.getAllowedOrigins()).thenReturn(List.of("https://trusted.example"));
+    SessionConfigurator configurator =
+        new SessionConfigurator(mock(ServiceLocator.class), zConf);
+
+    assertTrue(configurator.checkOrigin("https://trusted.example"));
+    assertFalse(configurator.checkOrigin("https://evil.example"));
+    assertFalse(configurator.checkOrigin("not a uri"));
+  }
+
+  @Test
+  void capturesTheServerAuthenticatedIdentityAndSecurityManager() {
+    ZeppelinConfiguration zConf = mock(ZeppelinConfiguration.class);
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    AuthenticatedIdentity identity =
+        new AuthenticatedIdentity("user1", java.util.Set.of("role1"), true, "session-id");
+    when(authenticationService.getAuthenticatedIdentity()).thenReturn(identity);
+    ServiceLocator serviceLocator = mock(ServiceLocator.class);
+    when(serviceLocator.getService(AuthenticationService.class)).thenReturn(authenticationService);
+    SessionConfigurator configurator = new SessionConfigurator(serviceLocator, zConf);
+    ServerEndpointConfig endpointConfig = ServerEndpointConfig.Builder
+        .create(NotebookServer.class, "/ws")
+        .build();
+    HandshakeRequest request = mock(HandshakeRequest.class);
+    when(request.getHeaders()).thenReturn(Map.of(
+        WatcherSecurityKey.HTTP_HEADER, List.of("watcher-key")));
+    SecurityManager securityManager = mock(SecurityManager.class);
+
+    ThreadContext.bind(securityManager);
+    try {
+      configurator.modifyHandshake(endpointConfig, request, mock(HandshakeResponse.class));
+    } finally {
+      ThreadContext.unbindSecurityManager();
+    }
+
+    assertSame(identity,
+        endpointConfig.getUserProperties().get(SessionConfigurator.AUTHENTICATED_IDENTITY));
+    assertSame(securityManager,
+        endpointConfig.getUserProperties().get(
+            SessionConfigurator.AUTHENTICATION_SECURITY_MANAGER));
+  }
+
+  @Test
+  void resolvesAuthenticationOnlyDuringTheFilteredHandshake() {
+    ZeppelinConfiguration zConf = mock(ZeppelinConfiguration.class);
+    AuthenticationService authenticationService = mock(AuthenticationService.class);
+    ServiceLocator serviceLocator = mock(ServiceLocator.class);
+    when(serviceLocator.getService(AuthenticationService.class)).thenReturn(authenticationService);
+
+    SessionConfigurator configurator = new SessionConfigurator(serviceLocator, zConf);
+
+    verify(serviceLocator, never()).getService(AuthenticationService.class);
+
+    ServerEndpointConfig endpointConfig = ServerEndpointConfig.Builder
+        .create(NotebookServer.class, "/ws")
+        .build();
+    HandshakeRequest request = mock(HandshakeRequest.class);
+    when(request.getHeaders()).thenReturn(Map.of());
+    configurator.modifyHandshake(endpointConfig, request, mock(HandshakeResponse.class));
+
+    verify(serviceLocator).getService(AuthenticationService.class);
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/WebSocketAuthenticationTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/WebSocketAuthenticationTest.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.gson.Gson;
+import org.apache.http.Header;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.zeppelin.MiniZeppelinServer;
+import org.apache.zeppelin.common.Message;
+import org.apache.zeppelin.common.Message.OP;
+import org.apache.zeppelin.notebook.AuthorizationService;
+import org.apache.zeppelin.rest.AbstractTestRestApi;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WebSocketAuthenticationTest extends AbstractTestRestApi {
+
+  private static final Gson GSON = new Gson();
+  private static MiniZeppelinServer zepServer;
+  private static WebSocketClient webSocketClient;
+
+  @BeforeAll
+  static void startServer() throws Exception {
+    zepServer = new MiniZeppelinServer(WebSocketAuthenticationTest.class.getSimpleName());
+    zepServer.addConfigFile("shiro.ini", ZEPPELIN_SHIRO);
+    zepServer.start();
+    allowServerOrigin(zepServer);
+    webSocketClient = new WebSocketClient();
+    webSocketClient.getHttpClient().setFollowRedirects(false);
+    webSocketClient.start();
+  }
+
+  @AfterAll
+  static void stopServer() throws Exception {
+    if (webSocketClient != null) {
+      webSocketClient.stop();
+    }
+    if (zepServer != null) {
+      zepServer.destroy();
+    }
+  }
+
+  @BeforeEach
+  void setUpConfiguration() {
+    zConf = zepServer.getZeppelinConfiguration();
+  }
+
+  @Test
+  void handshakeWithoutAnAuthenticatedRestSessionIsRejected() throws Exception {
+    HttpGet upgrade = new HttpGet(websocketUri().toString().replaceFirst("^ws", "http"));
+    upgrade.setHeader("Connection", "Upgrade");
+    upgrade.setHeader("Upgrade", "websocket");
+    upgrade.setHeader("Sec-WebSocket-Version", "13");
+    upgrade.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+    upgrade.setHeader("Origin", validOrigin());
+
+    try (CloseableHttpClient client = isolatedHttpClient();
+         CloseableHttpResponse response = client.execute(upgrade)) {
+      assertEquals(302, response.getStatusLine().getStatusCode());
+      Header location = response.getFirstHeader("Location");
+      assertNotNull(location);
+      assertEquals("/api/login", URI.create(location.getValue()).getPath());
+    }
+  }
+
+  @Test
+  void invalidOriginIsRejectedBeforeWebSocketOpen() throws Exception {
+    String cookie = login("/api", "user1", "password2");
+    TestSocket socket = new TestSocket();
+
+    ExecutionException failure = assertThrows(ExecutionException.class,
+        () -> connect(socket, cookie, "https://evil.example").get(10, TimeUnit.SECONDS));
+
+    UpgradeException upgradeException = findUpgradeException(failure);
+    assertNotNull(upgradeException);
+    assertEquals(403, upgradeException.getResponseStatusCode());
+    assertFalse(socket.isConnected());
+  }
+
+  @Test
+  void websocketUsesTheRestSessionAndIgnoresForgedMessageIdentity() throws Exception {
+    String cookie = login("/api", "user1", "password2");
+    TestSocket socket = new TestSocket();
+    Session session = connect(socket, cookie, validOrigin()).get(10, TimeUnit.SECONDS);
+    Message createNote = new Message(OP.NEW_NOTE)
+        .put("name", "/websocket-auth-" + System.nanoTime());
+    createNote.principal = "user2";
+    createNote.roles = "[\"admin\"]";
+    createNote.ticket = "forged-ticket";
+
+    session.getRemote().sendString(createNote.toJson());
+    Message response = socket.awaitMessage(OP.NEW_NOTE);
+    @SuppressWarnings("unchecked")
+    String noteId = String.valueOf(((Map<String, Object>) response.get("note")).get("id"));
+
+    AuthorizationService authorizationService = zepServer.getService(AuthorizationService.class);
+    assertEquals(Set.of("user1"), authorizationService.getOwners(noteId));
+    session.close();
+  }
+
+  @Test
+  void concurrentHandshakesKeepTheirServerIdentitiesIsolated() throws Exception {
+    String user1Cookie = login("/api", "user1", "password2");
+    String user2Cookie = login("/api", "user2", "password3");
+    TestSocket user1Socket = new TestSocket();
+    TestSocket user2Socket = new TestSocket();
+
+    CompletableFuture<Session> user1Future =
+        connect(user1Socket, user1Cookie, validOrigin());
+    CompletableFuture<Session> user2Future =
+        connect(user2Socket, user2Cookie, validOrigin());
+    Session user1Session = user1Future.get(10, TimeUnit.SECONDS);
+    Session user2Session = user2Future.get(10, TimeUnit.SECONDS);
+
+    user1Session.getRemote().sendString(
+        new Message(OP.NEW_NOTE).put("name", "/user1-" + System.nanoTime()).toJson());
+    user2Session.getRemote().sendString(
+        new Message(OP.NEW_NOTE).put("name", "/user2-" + System.nanoTime()).toJson());
+
+    String user1NoteId = noteId(user1Socket.awaitMessage(OP.NEW_NOTE));
+    String user2NoteId = noteId(user2Socket.awaitMessage(OP.NEW_NOTE));
+    AuthorizationService authorizationService = zepServer.getService(AuthorizationService.class);
+    assertEquals(Set.of("user1"), authorizationService.getOwners(user1NoteId));
+    assertEquals(Set.of("user2"), authorizationService.getOwners(user2NoteId));
+    user1Session.close();
+    user2Session.close();
+  }
+
+  @Test
+  void classicContextUsesItsAuthenticatingSecurityManager() throws Exception {
+    String cookie = login("/classic/api", "user1", "password2");
+    TestSocket socket = new TestSocket();
+    Session session = connect(
+        socket,
+        cookie,
+        validOrigin(),
+        URI.create("ws://localhost:" + zConf.getServerPort() + "/classic/ws"))
+        .get(10, TimeUnit.SECONDS);
+
+    session.getRemote().sendString(new Message(OP.LIST_NOTES).toJson());
+    socket.awaitMessage(OP.NOTES_INFO);
+    session.close();
+  }
+
+  @Test
+  void restLogoutInvalidatesTheWebSocketSession() throws Exception {
+    String cookie = login("/api", "user1", "password2");
+    TestSocket socket = new TestSocket();
+    Session session = connect(socket, cookie, validOrigin()).get(10, TimeUnit.SECONDS);
+
+    HttpPost logout = new HttpPost(getUrlToTest(zConf) + "/login/logout");
+    logout.setHeader("Origin", validOrigin());
+    logout.setHeader("Cookie", "JSESSIONID=" + cookie);
+    try (CloseableHttpClient client = isolatedHttpClient();
+         CloseableHttpResponse response = client.execute(logout)) {
+      assertEquals(401, response.getStatusLine().getStatusCode());
+    }
+    session.getRemote().sendString(new Message(OP.PING).toJson());
+    assertEquals(1008, socket.awaitCloseCode());
+  }
+
+  @Test
+  void reloginInvalidatesTheOldWebSocketAndIssuesAUsableNewSession() throws Exception {
+    String oldCookie = login("/api", "user1", "password2");
+    TestSocket oldSocket = new TestSocket();
+    Session oldSession = connect(oldSocket, oldCookie, validOrigin())
+        .get(10, TimeUnit.SECONDS);
+
+    HttpPost login = loginRequest("/api", "user2", "password3");
+    login.setHeader("Cookie", "JSESSIONID=" + oldCookie);
+    String newCookie;
+    try (CloseableHttpClient client = isolatedHttpClient();
+         CloseableHttpResponse response = client.execute(login)) {
+      assertEquals(200, response.getStatusLine().getStatusCode());
+      newCookie = sessionCookie(response);
+    }
+
+    assertNotEquals(oldCookie, newCookie);
+    oldSession.getRemote().sendString(new Message(OP.PING).toJson());
+    assertEquals(1008, oldSocket.awaitCloseCode());
+    TestSocket newSocket = new TestSocket();
+    Session newSession = connect(newSocket, newCookie, validOrigin())
+        .get(10, TimeUnit.SECONDS);
+    newSession.getRemote().sendString(new Message(OP.LIST_NOTES).toJson());
+    newSocket.awaitMessage(OP.NOTES_INFO);
+    newSession.close();
+  }
+
+  private CompletableFuture<Session> connect(
+      TestSocket socket, String sessionCookie, String origin) throws Exception {
+    return connect(socket, sessionCookie, origin, websocketUri());
+  }
+
+  private CompletableFuture<Session> connect(
+      TestSocket socket, String sessionCookie, String origin, URI uri) throws Exception {
+    ClientUpgradeRequest request = new ClientUpgradeRequest();
+    request.setHeader("Origin", origin);
+    if (sessionCookie != null) {
+      request.setHeader("Cookie", "JSESSIONID=" + sessionCookie);
+    }
+    return webSocketClient.connect(socket, uri, request);
+  }
+
+  private String login(String apiPath, String userName, String password) throws Exception {
+    try (CloseableHttpClient client = isolatedHttpClient();
+         CloseableHttpResponse response = client.execute(
+             loginRequest(apiPath, userName, password))) {
+      assertEquals(200, response.getStatusLine().getStatusCode());
+      return sessionCookie(response);
+    }
+  }
+
+  private HttpPost loginRequest(String apiPath, String userName, String password) {
+    HttpPost login = new HttpPost(
+        "http://localhost:" + zConf.getServerPort() + apiPath + "/login");
+    login.setHeader("Origin", validOrigin());
+    login.setEntity(new UrlEncodedFormEntity(List.of(
+        new BasicNameValuePair("userName", userName),
+        new BasicNameValuePair("password", password)), StandardCharsets.UTF_8));
+    return login;
+  }
+
+  private static String sessionCookie(CloseableHttpResponse response) {
+    Pattern pattern = Pattern.compile("JSESSIONID=([a-zA-Z0-9-]+)");
+    String sessionCookie = null;
+    for (Header header : response.getHeaders("Set-Cookie")) {
+      Matcher matcher = pattern.matcher(header.getValue());
+      if (matcher.find() && !header.getValue().contains("Max-Age=0")) {
+        sessionCookie = matcher.group(1);
+      }
+    }
+    if (sessionCookie == null) {
+      throw new AssertionError("Login did not issue a JSESSIONID cookie");
+    }
+    return sessionCookie;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static String noteId(Message response) {
+    return String.valueOf(((Map<String, Object>) response.get("note")).get("id"));
+  }
+
+  private static CloseableHttpClient isolatedHttpClient() {
+    return HttpClients.custom()
+        .disableCookieManagement()
+        .disableRedirectHandling()
+        .build();
+  }
+
+  private URI websocketUri() {
+    return URI.create("ws://localhost:" + zConf.getServerPort() + "/ws");
+  }
+
+  private String validOrigin() {
+    return "http://localhost:" + zConf.getServerPort();
+  }
+
+  private static void allowServerOrigin(MiniZeppelinServer server) {
+    server.getZeppelinConfiguration().setProperty(
+        org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_ALLOWED_ORIGINS
+            .getVarName(),
+        "http://localhost:" + server.getZeppelinConfiguration().getServerPort());
+  }
+
+  private static UpgradeException findUpgradeException(Throwable throwable) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (current instanceof UpgradeException) {
+        return (UpgradeException) current;
+      }
+      current = current.getCause();
+    }
+    return null;
+  }
+
+  private static final class TestSocket extends WebSocketAdapter {
+    private final BlockingQueue<String> messages = new LinkedBlockingQueue<>();
+    private final CompletableFuture<Integer> closeCode = new CompletableFuture<>();
+
+    @Override
+    public void onWebSocketText(String message) {
+      messages.add(message);
+    }
+
+    @Override
+    public void onWebSocketClose(int statusCode, String reason) {
+      closeCode.complete(statusCode);
+      super.onWebSocketClose(statusCode, reason);
+    }
+
+    Message awaitMessage(OP expectedOperation) throws Exception {
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+      while (true) {
+        long remaining = deadline - System.nanoTime();
+        if (remaining <= 0) {
+          break;
+        }
+        String serialized = messages.poll(remaining, TimeUnit.NANOSECONDS);
+        if (serialized == null) {
+          break;
+        }
+        Message message = GSON.fromJson(serialized, Message.class);
+        if (message.op == expectedOperation) {
+          return message;
+        }
+      }
+      throw new AssertionError("Did not receive WebSocket operation " + expectedOperation);
+    }
+
+    int awaitCloseCode() throws Exception {
+      return closeCode.get(10, TimeUnit.SECONDS);
+    }
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/WebSocketUrlPolicyAuthenticationTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/WebSocketUrlPolicyAuthenticationTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.zeppelin.MiniZeppelinServer;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.jupiter.api.Test;
+
+class WebSocketUrlPolicyAuthenticationTest {
+
+  private static final String ANONYMOUS_WEBSOCKET_SHIRO =
+      "[main]\n"
+          + "sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager\n"
+          + "securityManager.sessionManager = $sessionManager\n"
+          + "[urls]\n"
+          + "/api/version = anon\n"
+          + "/ws = anon\n"
+          + "/** = authc";
+
+  private static final String SHIRO_WITHOUT_CATCH_ALL =
+      "[main]\n"
+          + "sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager\n"
+          + "securityManager.sessionManager = $sessionManager\n"
+          + "[urls]\n"
+          + "/api/version = anon";
+
+  @Test
+  void defaultAnonymousPolicyAllowsClassicWebSocketFromLocalOrigin() throws Exception {
+    withServer(null, (server, webSocketClient) -> {
+      WebSocketAdapter socket = new WebSocketAdapter();
+      ClientUpgradeRequest request = new ClientUpgradeRequest();
+      request.setHeader("Origin", validOrigin(server));
+
+      URI classicWebSocketUri = URI.create("ws://localhost:"
+          + server.getZeppelinConfiguration().getServerPort() + "/classic/ws");
+      Session session = webSocketClient.connect(socket, classicWebSocketUri, request)
+          .get(10, TimeUnit.SECONDS);
+
+      assertTrue(session.isOpen());
+      assertTrue(socket.isConnected());
+      session.close();
+    });
+  }
+
+  @Test
+  void explicitAnonymousRuleAllowsWebSocketWithoutRestSession() throws Exception {
+    withServer(ANONYMOUS_WEBSOCKET_SHIRO, (server, webSocketClient) -> {
+      WebSocketAdapter socket = new WebSocketAdapter();
+      ClientUpgradeRequest request = new ClientUpgradeRequest();
+      request.setHeader("Origin", validOrigin(server));
+
+      Session session = webSocketClient.connect(socket, websocketUri(server), request)
+          .get(10, TimeUnit.SECONDS);
+
+      assertTrue(session.isOpen());
+      assertTrue(socket.isConnected());
+      session.close();
+    });
+  }
+
+  @Test
+  void unmatchedRestAndWebSocketRequestsFailClosed() throws Exception {
+    withServer(SHIRO_WITHOUT_CATCH_ALL, (server, webSocketClient) -> {
+      ClientUpgradeRequest request = new ClientUpgradeRequest();
+      request.setHeader("Origin", validOrigin(server));
+
+      ExecutionException failure = assertThrows(ExecutionException.class,
+          () -> webSocketClient.connect(new WebSocketAdapter(), websocketUri(server), request)
+              .get(10, TimeUnit.SECONDS));
+      UpgradeException upgradeException = findUpgradeException(failure);
+      assertNotNull(upgradeException);
+      assertEquals(403, upgradeException.getResponseStatusCode());
+
+      URL unmatchedRestUrl = URI.create(validOrigin(server) + "/api/unmatched").toURL();
+      HttpURLConnection connection = (HttpURLConnection) unmatchedRestUrl.openConnection();
+      connection.setInstanceFollowRedirects(false);
+      connection.setRequestProperty("Origin", validOrigin(server));
+      try {
+        assertEquals(403, connection.getResponseCode());
+      } finally {
+        connection.disconnect();
+      }
+    });
+  }
+
+  private static void withServer(String shiroIni, ServerTest test) throws Exception {
+    MiniZeppelinServer server =
+        new MiniZeppelinServer(WebSocketUrlPolicyAuthenticationTest.class.getSimpleName());
+    WebSocketClient webSocketClient = new WebSocketClient();
+    try {
+      if (shiroIni != null) {
+        server.addConfigFile("shiro.ini", shiroIni);
+      }
+      server.start();
+      webSocketClient.start();
+      test.run(server, webSocketClient);
+    } finally {
+      try {
+        webSocketClient.stop();
+      } finally {
+        server.destroy();
+      }
+    }
+  }
+
+  private static URI websocketUri(MiniZeppelinServer server) {
+    return URI.create("ws://localhost:"
+        + server.getZeppelinConfiguration().getServerPort() + "/ws");
+  }
+
+  private static String validOrigin(MiniZeppelinServer server) {
+    return "http://localhost:" + server.getZeppelinConfiguration().getServerPort();
+  }
+
+  private static UpgradeException findUpgradeException(Throwable throwable) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (current instanceof UpgradeException) {
+        return (UpgradeException) current;
+      }
+      current = current.getCause();
+    }
+    return null;
+  }
+
+  @FunctionalInterface
+  private interface ServerTest {
+    void run(MiniZeppelinServer server, WebSocketClient client) throws Exception;
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/utils/CorsUtilsTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/utils/CorsUtilsTest.java
@@ -18,6 +18,7 @@ package org.apache.zeppelin.utils;
 
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetAddress;
@@ -30,25 +31,26 @@ class CorsUtilsTest {
 
   @Test
   void isInvalid() throws URISyntaxException, UnknownHostException {
-    assertFalse(CorsUtils.isValidOrigin("http://127.0.1.1", ZeppelinConfiguration.load()));
+    assertFalse(CorsUtils.isValidOrigin("http://127.0.1.1", localOriginConfiguration()));
   }
 
   @Test
   void isInvalidFromConfig()
       throws URISyntaxException, UnknownHostException {
     assertFalse(CorsUtils.isValidOrigin("http://otherinvalidhost.com",
-        ZeppelinConfiguration.load("zeppelin-site.xml")));
+        ZeppelinConfiguration.load("test-zeppelin-site2.xml")));
   }
 
   @Test
   void isLocalhost() throws URISyntaxException, UnknownHostException {
-    assertTrue(CorsUtils.isValidOrigin("http://localhost", ZeppelinConfiguration.load()));
+    assertTrue(CorsUtils.isValidOrigin("http://localhost:8080", localOriginConfiguration()));
+    assertTrue(CorsUtils.isValidOrigin("http://[::1]:8080", localOriginConfiguration()));
   }
 
   @Test
   void isLocalMachine() throws URISyntaxException, UnknownHostException {
-    String origin = "http://" + InetAddress.getLocalHost().getHostName();
-    assertTrue(CorsUtils.isValidOrigin(origin, ZeppelinConfiguration.load()),
+    String origin = "http://" + InetAddress.getLocalHost().getHostName() + ":8080";
+    assertTrue(CorsUtils.isValidOrigin(origin, localOriginConfiguration()),
       "Origin " + origin + " is not allowed. Please check your hostname.");
   }
 
@@ -56,7 +58,14 @@ class CorsUtilsTest {
   void isValidFromConfig()
       throws URISyntaxException, UnknownHostException {
     assertTrue(CorsUtils.isValidOrigin("http://otherhost.com",
-        ZeppelinConfiguration.load("zeppelin-site.xml")));
+        ZeppelinConfiguration.load("test-zeppelin-site2.xml")));
+  }
+
+  @Test
+  void configuredAllowlistDoesNotImplicitlyIncludeLocalhost()
+      throws URISyntaxException, UnknownHostException {
+    assertFalse(CorsUtils.isValidOrigin("http://localhost:8080",
+        ZeppelinConfiguration.load("test-zeppelin-site2.xml")));
   }
 
   @Test
@@ -76,7 +85,7 @@ class CorsUtilsTest {
   @Test
   void nullOriginWithStar()
       throws URISyntaxException, UnknownHostException {
-    assertTrue(CorsUtils.isValidOrigin(null,
+    assertFalse(CorsUtils.isValidOrigin(null,
         ZeppelinConfiguration.load("zeppelin-site-star.xml")));
   }
 
@@ -89,8 +98,33 @@ class CorsUtilsTest {
 
   @Test
   void notAURIOrigin()
+      throws UnknownHostException {
+    assertThrows(URISyntaxException.class, () -> CorsUtils.isValidOrigin(
+        "test123", ZeppelinConfiguration.load("zeppelin-site.xml")));
+  }
+
+  @Test
+  void localOriginMustMatchTheConfiguredSchemeAndPort()
       throws URISyntaxException, UnknownHostException {
-    assertFalse(CorsUtils.isValidOrigin("test123",
-        ZeppelinConfiguration.load("zeppelin-site.xml")));
+    ZeppelinConfiguration zConf = localOriginConfiguration();
+
+    assertFalse(CorsUtils.isValidOrigin("http://localhost:8081", zConf));
+    assertFalse(CorsUtils.isValidOrigin("https://localhost:8080", zConf));
+  }
+
+  @Test
+  void rejectsOriginComponentsOutsideTheOriginTuple() {
+    ZeppelinConfiguration zConf = ZeppelinConfiguration.load("zeppelin-site-star.xml");
+
+    assertThrows(URISyntaxException.class,
+        () -> CorsUtils.isValidOrigin("http://localhost:8080/path", zConf));
+    assertThrows(URISyntaxException.class,
+        () -> CorsUtils.isValidOrigin("http://user@localhost:8080", zConf));
+    assertThrows(URISyntaxException.class,
+        () -> CorsUtils.isValidOrigin("http://localhost:8080?query", zConf));
+  }
+
+  private static ZeppelinConfiguration localOriginConfiguration() {
+    return ZeppelinConfiguration.load("zeppelin-site.xml");
   }
 }

--- a/zeppelin-server/src/test/resources/zeppelin-site.xml
+++ b/zeppelin-server/src/test/resources/zeppelin-site.xml
@@ -142,7 +142,7 @@
 
   <property>
     <name>zeppelin.server.allowed.origins</name>
-    <value>http://onehost:8080,http://otherhost.com,</value>
+    <value></value>
     <description>Allowed sources for REST and WebSocket requests.</description>
   </property>
 <!--


### PR DESCRIPTION
### What is this PR for?

Use one ordered Shiro `[urls]` policy for both REST requests under `/api/*` and the notebook WebSocket handshake at `/ws`. The first matching rule wins, explicit `anon` rules remain supported, and unmatched REST/WebSocket requests fail closed.

The handshake captures one immutable server-authenticated identity with its exact Shiro session and `SecurityManager`. REST and WebSocket both derive their authorization `ServiceContext` from that identity. WebSocket sessions are revalidated before inbound dispatch and outbound delivery, and client-supplied principal, role, or ticket fields are not trusted for authorization.

The change also:

* keeps Shiro and upgrades it to 2.2.1, with Bouncy Castle 1.84 for dependency convergence;
* enforces exact Origin tuples for credentialed REST and WebSocket traffic;
* preserves logout, relogin, expiration, concurrent handshake, classic UI context, and Kerberos session behavior;
* carries each Java client's scoped REST session cookie into its WebSocket upgrade and closes client transports deterministically;
* documents first-match include/exclude patterns and the Shiro session requirement for authenticated WebSockets.

No Jetty upgrade is required. Operators can opt into anonymous WebSockets by placing `/ws = anon` before the catch-all rule.

The patch was re-audited and reduced from 60 to 51 files: 18 production files, 7 configuration/documentation/build files, and 26 test files. It contains no frontend, notebook-storage, or notebook-repository change.

### What type of PR is it?

Improvement

### Todos

* [x] Apply one first-match Shiro URL policy to REST and WebSocket
* [x] Reject unmatched REST and WebSocket authentication paths
* [x] Bind WebSockets to the exact server-authenticated Shiro session
* [x] Cover logout, relogin, expiration, identity isolation, Origin, and anonymous opt-out
* [x] Update client cookie and lifecycle behavior
* [x] Update configuration templates and documentation
* [ ] Link the Jira issue and add its key to the PR title
* [x] Confirm GitHub CI on this exact head

### What is the Jira issue?

* To be created or linked before marking this PR ready for review.

### How should this be tested?

Local validation on exact head `639b64bad`, based directly on `apache/master` `cb219f607`:

* full clean `zeppelin-server` suite: 1,699 tests, 0 failures, 0 errors, 19 skipped;
* focused real-Shiro context and authentication service tests: 15 tests, 0 failures/errors;
* focused legacy Selenium authentication and personalization suites: 6 tests, 0 failures/errors;
* clean `zeppelin-client` suite: 8 tests, 0 failures/errors;
* authenticated Java-client integration suite: 5 tests, 0 failures/errors, all 12 reactor modules successful;
* Apache RAT across all 56 reactor modules: success, 0 unapproved files;
* Maven validate across all 56 reactor modules: success;
* Maven dependency convergence: success in the server and client reactors.
* GitHub Actions on exact head `639b64bad`: 19/19 checks passed, 0 failed, 0 pending (including core, integration, Selenium, authenticated and anonymous Playwright, Spark, Flink, Livy, Windows, license, and validation jobs).

Useful commands:

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 11) ./mvnw -pl zeppelin-server -Dmaven.gitcommitid.skip=true -Dmdep.skip=true clean test
JAVA_HOME=$(/usr/libexec/java_home -v 11) ./mvnw -pl zeppelin-client -Dmaven.gitcommitid.skip=true clean test
./mvnw apache-rat:check -Prat -Dmaven.gitcommitid.skip=true
```

### Screenshots (if appropriate)

Not applicable.

### Questions

* Does the license files need to update? No.
* Is there breaking changes for older versions? Security-sensitive defaults are stricter. Cross-origin deployments must configure `zeppelin.server.allowed.origins`, anonymous WebSockets require an explicit `/ws = anon`, and custom Shiro environments must preserve the documented session lifecycle guarantees.
* Does this needs documentation? Yes. The Shiro, configuration, REST, and Java-client documentation is updated in this PR.



