### PR TITLE
[ZEPPELIN-6340] Add ZeppelinEventBus and update NotebookServer to handle NoteRemoveEvent

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -840,4 +840,10 @@
   <description>fields to be excluded from being saved in note files, with Paragraph prefix mean the fields in Paragraph, e.g. Paragraph.results</description>
 </property>
 
+<property>
+  <name>zeppelin.eventbus.enabled</name>
+  <value>false</value>
+  <description>Enables the new event-driven architecture using an in-process EventBus</description>
+</property>
+
 </configuration>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -98,6 +98,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.reactivex.rxjava3</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>3.1.12</version>
+    </dependency>
+
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -941,6 +941,8 @@ public class ZeppelinConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_METRIC_ENABLE_PROMETHEUS);
   }
 
+  public boolean isEventBusEnabled() { return getBoolean(ConfVars.ZEPPELIN_EVENTBUS_ENABLED); }
+
   public DEFAULT_UI getDefaultUi() {
     return DEFAULT_UI.valueOf(getString(ConfVars.ZEPPELIN_DEFAULT_UI).toUpperCase());
   }
@@ -1187,7 +1189,8 @@ public class ZeppelinConfiguration {
     ZEPPELIN_SPARK_ONLY_YARN_CLUSTER("zeppelin.spark.only_yarn_cluster", false),
     ZEPPELIN_SESSION_CHECK_INTERVAL("zeppelin.session.check_interval", 60 * 10 * 1000),
     ZEPPELIN_NOTE_CACHE_THRESHOLD("zeppelin.note.cache.threshold", 50),
-    ZEPPELIN_NOTE_FILE_EXCLUDE_FIELDS("zeppelin.note.file.exclude.fields", "");
+    ZEPPELIN_NOTE_FILE_EXCLUDE_FIELDS("zeppelin.note.file.exclude.fields", ""),
+    ZEPPELIN_EVENTBUS_ENABLED("zeppelin.eventbus.enabled", false);
 
     private String varName;
     private Class<?> varClass;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/EventBus.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/EventBus.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.eventbus;
+
+import io.reactivex.rxjava3.core.Observable;
+
+public interface EventBus {
+
+  void post(ZeppelinEvent event);
+
+  <T extends ZeppelinEvent> Observable<T> observe(Class<T> eventType);
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/NoOpEventBus.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/NoOpEventBus.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.eventbus;
+
+import io.reactivex.rxjava3.core.Observable;
+import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NoOpEventBus implements EventBus {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(NoOpEventBus.class);
+
+  @Inject
+  public NoOpEventBus() {
+    LOGGER.info("Starting NoOpEventBus");
+  }
+
+  @Override
+  public void post(ZeppelinEvent event) {
+    LOGGER.debug("Posting event: {}", event.getClass().getName());
+  }
+
+  @Override
+  public <T extends ZeppelinEvent> Observable<T> observe(Class<T> eventType) {
+    return Observable.empty();
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/NoteEvent.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/NoteEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.eventbus;
+
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.user.AuthenticationInfo;
+
+public interface NoteEvent extends ZeppelinEvent {
+
+  Note getNote();
+
+  AuthenticationInfo getSubject();
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/NoteRemovedEvent.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/NoteRemovedEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.eventbus;
+
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.user.AuthenticationInfo;
+
+public class NoteRemovedEvent implements NoteEvent {
+
+  private final Note note;
+
+  private final AuthenticationInfo subject;
+
+  public NoteRemovedEvent(Note note, AuthenticationInfo subject) {
+    this.note = note;
+    this.subject = subject;
+  }
+
+  @Override
+  public Note getNote() {
+    return this.note;
+  }
+
+  @Override
+  public AuthenticationInfo getSubject() {
+    return subject;
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/ZeppelinEvent.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/ZeppelinEvent.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.eventbus;
+
+public interface ZeppelinEvent {
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/ZeppelinEventBus.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/eventbus/ZeppelinEventBus.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.eventbus;
+
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.subjects.PublishSubject;
+import io.reactivex.rxjava3.subjects.Subject;
+import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ZeppelinEventBus implements EventBus {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinEventBus.class);
+
+  private final Subject<ZeppelinEvent> eventBus;
+
+  @Inject
+  public ZeppelinEventBus() {
+    LOGGER.info("Starting ZeppelinEventBus");
+
+    eventBus = PublishSubject.<ZeppelinEvent>create().toSerialized();
+  }
+
+  @Override
+  public void post(ZeppelinEvent event) {
+    LOGGER.debug("Posting event: {}", event.getClass().getName());
+
+    eventBus.onNext(event);
+  }
+
+  @Override
+  public <T extends ZeppelinEvent> Observable<T> observe(Class<T> eventType) {
+    LOGGER.debug("Observing event: {}", eventType.getName());
+
+    return eventBus.ofType(eventType);
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -44,6 +44,8 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
+import org.apache.zeppelin.eventbus.EventBus;
+import org.apache.zeppelin.eventbus.NoteRemovedEvent;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
@@ -86,11 +88,13 @@ public class Notebook {
   private Credentials credentials;
   private final List<Consumer<String>> initConsumers;
   private ExecutorService initExecutor;
+  private EventBus eventBus;
 
   /**
    * Main constructor \w manual Dependency Injection
    *
    * @throws IOException
+   *
    * @throws SchedulerException
    */
   public Notebook(
@@ -100,8 +104,8 @@ public class Notebook {
       NoteManager noteManager,
       InterpreterFactory replFactory,
       InterpreterSettingManager interpreterSettingManager,
-      Credentials credentials)
-      {
+      Credentials credentials,
+      EventBus eventBus) {
     this.zConf = zConf;
     this.authorizationService = authorizationService;
     this.noteManager = noteManager;
@@ -111,6 +115,7 @@ public class Notebook {
     // TODO(zjffdu) cycle refer, not a good solution
     this.interpreterSettingManager.setNotebook(this);
     this.credentials = credentials;
+    this.eventBus = eventBus;
     addNotebookEventListener(this.interpreterSettingManager);
     initConsumers = new LinkedList<>();
   }
@@ -221,7 +226,8 @@ public class Notebook {
       InterpreterFactory replFactory,
       InterpreterSettingManager interpreterSettingManager,
       Credentials credentials,
-      NoteEventListener noteEventListener)
+      NoteEventListener noteEventListener,
+      EventBus eventBus)
       throws IOException {
     this(
         zConf,
@@ -230,7 +236,8 @@ public class Notebook {
         noteManager,
         replFactory,
         interpreterSettingManager,
-        credentials);
+        credentials,
+        eventBus);
     if (null != noteEventListener) {
       addNotebookEventListener(noteEventListener);
     }
@@ -432,7 +439,11 @@ public class Notebook {
     note.setRemoved(true);
     noteManager.removeNote(note.getId(), subject);
     authorizationService.removeNoteAuth(note.getId());
+
     fireNoteRemoveEvent(note, subject);
+    if (zConf.isEventBusEnabled()) {
+      eventBus.post(new NoteRemovedEvent(note, subject));
+    }
   }
 
   public void removeCorruptedNote(String noteId, AuthenticationInfo subject) throws IOException {
@@ -564,6 +575,9 @@ public class Notebook {
             note.setRemoved(true);
             authorizationService.removeNoteAuth(note.getId());
             fireNoteRemoveEvent(note, subject);
+            if (zConf.isEventBusEnabled()) {
+              eventBus.post(new NoteRemovedEvent(note, subject));
+            }
           }
           return null;
         });
@@ -842,6 +856,7 @@ public class Notebook {
       listener.onNoteUpdate(note, subject);
     }
   }
+
 
   private void fireNoteRemoveEvent(Note note, AuthenticationInfo subject) {
     for (NoteEventListener listener : noteEventListeners) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -64,6 +64,9 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.DEFAULT_UI;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
+import org.apache.zeppelin.eventbus.EventBus;
+import org.apache.zeppelin.eventbus.NoOpEventBus;
+import org.apache.zeppelin.eventbus.ZeppelinEventBus;
 import org.apache.zeppelin.healthcheck.HealthChecks;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.helium.Helium;
@@ -179,6 +182,11 @@ public class ZeppelinServer implements AutoCloseable {
             bind(storage).to(ConfigStorage.class);
             bindAsContract(PluginManager.class).in(Singleton.class);
             bind(GsonNoteParser.class).to(NoteParser.class).in(Singleton.class);
+            if (zConf.isEventBusEnabled()) {
+              bind(ZeppelinEventBus.class).to(EventBus.class).in(Singleton.class);
+            } else {
+              bind(NoOpEventBus.class).to(EventBus.class).in(Singleton.class);
+            }
             bindAsContract(InterpreterFactory.class).in(Singleton.class);
             bindAsContract(NotebookRepoSync.class).to(NotebookRepo.class).in(Singleton.class);
             bindAsContract(Helium.class).in(Singleton.class);
@@ -362,6 +370,7 @@ public class ZeppelinServer implements AutoCloseable {
           if (!zConf.isRecoveryEnabled()) {
             sharedServiceLocator.getService(InterpreterSettingManager.class).close();
           }
+          sharedServiceLocator.getService(NotebookServer.class).close();
           sharedServiceLocator.getService(Notebook.class).close();
         }
       } catch (Exception e) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -42,6 +42,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.websocket.CloseReason;
@@ -64,6 +66,9 @@ import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
 import org.apache.zeppelin.display.GUI;
 import org.apache.zeppelin.display.Input;
+import org.apache.zeppelin.eventbus.EventBus;
+import org.apache.zeppelin.eventbus.NoteEvent;
+import org.apache.zeppelin.eventbus.NoteRemovedEvent;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.helium.HeliumPackage;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
@@ -120,7 +125,8 @@ public class NotebookServer implements AngularObjectRegistryListener,
     RemoteInterpreterProcessListener,
     ApplicationEventListener,
     ParagraphJobListener,
-    NoteEventListener {
+    NoteEventListener,
+    AutoCloseable {
 
   /**
    * Job manager service type.
@@ -164,6 +170,7 @@ public class NotebookServer implements AngularObjectRegistryListener,
   private AuthorizationService authorizationService;
   private Provider<ConfigurationService> configurationServiceProvider;
   private Provider<JobManagerService> jobManagerServiceProvider;
+  private CompositeDisposable subscriptions;
 
   public NotebookServer() {
     NotebookServer.self.set(this);
@@ -173,6 +180,31 @@ public class NotebookServer implements AngularObjectRegistryListener,
   @Inject
   public void setZeppelinConfiguration(ZeppelinConfiguration zConf) {
     this.zConf = zConf;
+  }
+
+  @Inject
+  public void registerEventBus(EventBus eventBus, ZeppelinConfiguration zConf) {
+    if (!zConf.isEventBusEnabled()) {
+      LOGGER.debug("ZeppelinEventBus is disabled");
+      return;
+    }
+    subscriptions = new CompositeDisposable();
+
+    subscriptions.add(eventBus.observe(NoteEvent.class)
+        .subscribe(event -> {
+          try {
+            handleNoteEvent(event);
+          } catch (Exception e) {
+            LOGGER.error("Failed to handle note event: {}", event, e);
+          }
+        }));
+  }
+
+  @Override
+  public void close() {
+    if (subscriptions != null && !subscriptions.isDisposed()) {
+      subscriptions.dispose();
+    }
   }
 
   @Inject
@@ -1980,19 +2012,12 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
   @Override
   public void onNoteRemove(Note note, AuthenticationInfo subject) {
-    try {
-      broadcastUpdateNoteJobInfo(note, System.currentTimeMillis() - 5000);
-    } catch (IOException e) {
-      LOGGER.warn("can not broadcast for job manager: {}", e.getMessage(), e);
+    if (zConf.isEventBusEnabled()) {
+      LOGGER.debug("ZeppelinEventBus is enabled");
+      return;
     }
 
-    try {
-      getJobManagerService().removeNoteJobInfo(note.getId(), null,
-          new JobManagerServiceCallback());
-    } catch (IOException e) {
-      LOGGER.warn("can not broadcast for job manager: {}", e.getMessage(), e);
-    }
-
+    handleNoteRemove(note);
   }
 
   @Override
@@ -2432,6 +2457,30 @@ public class NotebookServer implements AngularObjectRegistryListener,
         }
         conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info", message)));
       }
+    }
+  }
+
+  private void handleNoteEvent(NoteEvent event) {
+    if (event instanceof NoteRemovedEvent) {
+      Note note = event.getNote();
+      handleNoteRemove(note);
+    } else {
+      LOGGER.warn("Unknown event type: {}", event.getClass().getName());
+    }
+  }
+
+  private void handleNoteRemove(Note note) {
+    try {
+      broadcastUpdateNoteJobInfo(note, System.currentTimeMillis() - 5000);
+    } catch (IOException e) {
+      LOGGER.warn("can not broadcast for job manager: {}", e.getMessage(), e);
+    }
+
+    try {
+      getJobManagerService().removeNoteJobInfo(note.getId(), null,
+          new JobManagerServiceCallback());
+    } catch (IOException e) {
+      LOGGER.warn("can not broadcast for job manager: {}", e.getMessage(), e);
     }
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/eventbus/RxJavaTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/eventbus/RxJavaTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.eventbus;
+
+import io.reactivex.rxjava3.core.Observable;
+import org.junit.jupiter.api.Test;
+
+class RxJavaTest {
+
+  @Test
+  void testObservable() {
+    Observable<String> observable = Observable.just("Hello", "RxJava", "Test");
+
+    observable.test()
+        .assertValues("Hello", "RxJava", "Test")
+        .assertComplete()
+        .assertNoErrors();
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/eventbus/ZeppelinEventBusTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/eventbus/ZeppelinEventBusTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.eventbus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.reactivex.rxjava3.disposables.Disposable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class ZeppelinEventBusTest {
+
+  @Test
+  void eventBusFlow() throws InterruptedException {
+    ZeppelinEventBus bus = new ZeppelinEventBus();
+    Publisher publisher = new Publisher(bus);
+    Subscriber subscriber = new Subscriber(bus);
+
+    String payload = "data";
+    publisher.createNote(payload);
+
+    assertTrue(subscriber.awaitEvent());
+
+    List<String> received = subscriber.collection;
+    assertEquals(1, received.size());
+    assertEquals(payload, received.get(0));
+    assertTrue(received.contains(payload));
+
+    subscriber.stopListening();
+  }
+
+  private static class MockEvent implements ZeppelinEvent {
+    private final String payload;
+
+    MockEvent(String payload) {
+      this.payload = payload;
+    }
+  }
+
+  private static class Publisher {
+    private final ZeppelinEventBus eventBus;
+
+    Publisher(ZeppelinEventBus eventBus) {
+      this.eventBus = eventBus;
+    }
+
+    void createNote(String noteId) {
+      eventBus.post(new MockEvent(noteId));
+    }
+  }
+
+  private static class Subscriber {
+    private final List<String> collection = new ArrayList<>();
+
+    private final CountDownLatch eventReceived = new CountDownLatch(1);
+
+    private final Disposable disposable;
+
+    Subscriber(ZeppelinEventBus eventBus) {
+      this.disposable = eventBus.observe(MockEvent.class)
+          .subscribe(event -> {
+            collection.add(event.payload);
+            eventReceived.countDown();
+          });
+    }
+
+    boolean awaitEvent() throws InterruptedException {
+      return eventReceived.await(1, TimeUnit.SECONDS);
+    }
+
+    void stopListening() {
+      if (!disposable.isDisposed()) {
+        disposable.dispose();
+      }
+    }
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -70,7 +70,8 @@ class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
             new NoteManager(notebookRepo, ZeppelinConfiguration.load()),
             interpreterFactory,
             interpreterSettingManager,
-            new Credentials());
+            new Credentials(),
+            eventBus);
 
     heliumAppFactory = new HeliumApplicationFactory(notebook, null);
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
@@ -21,6 +21,7 @@ package org.apache.zeppelin.interpreter;
 import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
+import org.apache.zeppelin.eventbus.ZeppelinEventBus;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.notebook.AuthorizationService;
@@ -65,6 +66,7 @@ public abstract class AbstractInterpreterTest {
   protected ZeppelinConfiguration zConf;
   protected ConfigStorage storage;
   protected PluginManager pluginManager;
+  protected ZeppelinEventBus eventBus;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -100,12 +102,12 @@ public abstract class AbstractInterpreterTest {
     zConf.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_GROUP_DEFAULT.getVarName(),
         "test");
 
-
     NotebookRepo notebookRepo = new InMemoryNotebookRepo();
     NoteManager noteManager = new NoteManager(notebookRepo, zConf);
     noteParser = new GsonNoteParser(zConf);
     storage = ConfigStorage.createConfigStorage(zConf);
     pluginManager = new PluginManager(zConf);
+    eventBus = new ZeppelinEventBus();
     AuthorizationService authorizationService =
         new AuthorizationService(noteManager, zConf, storage);
 
@@ -114,7 +116,7 @@ public abstract class AbstractInterpreterTest {
         mock(ApplicationEventListener.class), storage, pluginManager);
     interpreterFactory = new InterpreterFactory(interpreterSettingManager);
     Credentials credentials = new Credentials(zConf, storage);
-    notebook = new Notebook(zConf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials);
+    notebook = new Notebook(zConf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials, eventBus);
     interpreterSettingManager.setNotebook(notebook);
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObjectRegistry;
+import org.apache.zeppelin.eventbus.ZeppelinEventBus;
 import org.apache.zeppelin.interpreter.AbstractInterpreterTest;
 import org.apache.zeppelin.interpreter.ExecutionContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
@@ -107,7 +108,8 @@ class NotebookTest extends AbstractInterpreterTest implements ParagraphJobListen
     authorizationService = new AuthorizationService(noteManager, zConf, storage);
 
     credentials = new Credentials(zConf, storage);
-    notebook = new Notebook(zConf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials, null);
+    ZeppelinEventBus eventBus = new ZeppelinEventBus();
+    notebook = new Notebook(zConf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials, eventBus);
     notebook.setParagraphJobListener(this);
     schedulerService = new QuartzSchedulerService(zConf, notebook);
     notebook.initNotebook();
@@ -1710,7 +1712,7 @@ class NotebookTest extends AbstractInterpreterTest implements ParagraphJobListen
   }
 
   @Test
-  void testRemoveFolderFiresNoteRemoveEventForEachNote() throws IOException {
+  void testRemoveFolderFiresNoteRemovedEventForEachNote() throws IOException {
     final AtomicInteger onNoteRemove = new AtomicInteger(0);
     notebook.addNotebookEventListener(new NoteEventListener() {
       @Override

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -39,6 +39,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
+import org.apache.zeppelin.eventbus.EventBus;
+import org.apache.zeppelin.eventbus.ZeppelinEventBus;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
@@ -76,6 +78,7 @@ class NotebookRepoSyncTest {
   private InterpreterFactory factory;
   private InterpreterSettingManager interpreterSettingManager;
   private Credentials credentials;
+  private EventBus eventBus;
   private AuthenticationInfo anonymous;
   private NoteManager noteManager;
   private AuthorizationService authorizationService;
@@ -116,7 +119,8 @@ class NotebookRepoSyncTest {
     noteManager = new NoteManager(notebookRepoSync, zConf);
     authorizationService = new AuthorizationService(noteManager, zConf, storage);
     credentials = new Credentials(zConf, storage);
-    notebook = new Notebook(zConf, authorizationService, notebookRepoSync, noteManager, factory, interpreterSettingManager, credentials, null);
+    eventBus = new ZeppelinEventBus();
+    notebook = new Notebook(zConf, authorizationService, notebookRepoSync, noteManager, factory, interpreterSettingManager, credentials, eventBus);
     anonymous = new AuthenticationInfo("anonymous");
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -49,6 +49,8 @@ import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.eventbus.EventBus;
+import org.apache.zeppelin.eventbus.ZeppelinEventBus;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.Interpreter.FormType;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
@@ -83,9 +85,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.TestInfo;
-
-
-import com.google.gson.Gson;
 
 class NotebookServiceTest {
 
@@ -147,6 +146,7 @@ class NotebookServiceTest {
     Credentials credentials = new Credentials();
     NoteManager noteManager = new NoteManager(notebookRepo, zConf);
     authorizationService = new AuthorizationService(noteManager, zConf, storage);
+    EventBus eventBus = new ZeppelinEventBus();
     notebook =
         new Notebook(
             zConf,
@@ -156,7 +156,7 @@ class NotebookServiceTest {
             mockInterpreterFactory,
             mockInterpreterSettingManager,
             credentials,
-            null);
+            eventBus);
     searchService = new LuceneSearch(zConf, notebook);
     QuartzSchedulerService schedulerService = new QuartzSchedulerService(zConf, notebook);
     notebook.initNotebook();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -52,6 +52,9 @@ import org.apache.thrift.TException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectBuilder;
+import org.apache.zeppelin.eventbus.EventBus;
+import org.apache.zeppelin.eventbus.NoteRemovedEvent;
+import org.apache.zeppelin.eventbus.ZeppelinEventBus;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
@@ -70,6 +73,7 @@ import org.apache.zeppelin.common.Message.OP;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
+import org.apache.zeppelin.service.JobManagerService;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -191,6 +195,32 @@ class NotebookServerTest extends AbstractTestRestApi {
     } finally {
       restoreJobManagerFlag(originalFlag);
     }
+  }
+
+  @Test
+  void testEventBusHandlesNoteRemovedEvent() throws IOException {
+    ZeppelinConfiguration conf = ZeppelinConfiguration.load();
+    conf.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_EVENTBUS_ENABLED.getVarName(), "true");
+
+    EventBus eventBus = new ZeppelinEventBus();
+    NotebookServer server = new NotebookServer();
+    AuthorizationService mockAuthorizationService = mock(AuthorizationService.class);
+    JobManagerService mockJobManagerService = mock(JobManagerService.class);
+    Note note = new Note();
+
+    when(mockAuthorizationService.getOwners(note.getId())).thenReturn(new HashSet<>());
+
+    server.setZeppelinConfiguration(conf);
+    server.setAuthorizationService(mockAuthorizationService);
+    server.setJobManagerService(() -> mockJobManagerService);
+    server.registerEventBus(eventBus, conf);
+
+    eventBus.post(new NoteRemovedEvent(note, AuthenticationInfo.ANONYMOUS));
+
+    verify(mockJobManagerService).getNoteJobInfoByUnixTime(Mockito.anyLong(), Mockito.any(), Mockito.any());
+    verify(mockJobManagerService).removeNoteJobInfo(eq(note.getId()), Mockito.isNull(), Mockito.any());
+
+    server.close();
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?

This PR is the first step toward migrating Zeppelin’s listener-based event handling to an EventBus model, as outlined in the [proposal](https://cwiki.apache.org/confluence/x/vAsGFw). It sets up the EventBus infrastructure and migrates `NoteRemoveEvent` handling to it.

Key changes:

* Added the `ZeppelinEventBus` class
* Added RxJava 3 as a dependency of the `zeppelin-zengine` module
* Added the `zeppelin.eventbus.enabled` feature flag
* Updated `NotebookServer` to handle `NoteRemoveEvent` through `ZeppelinEventBus` when the feature flag is enabled

This PR supersedes #5085. The original branch had fallen behind the current codebase, and the implementation has since changed, so I opened a new PR.
### What type of PR is it?
Improvement

### Todos
* [ ] Refactor other NoteEventListener methods and additional listeners to EventBus

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6340

### How should this be tested?
- Run the existing test suite against the updated code  
- Verify the note deletion flow through the UI

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N