### PR TITLE
[ZEPPELIN-6691] Terminate shell terminal process on WebSocket close

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalManager.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalManager.java
@@ -69,7 +69,7 @@ public class TerminalManager {
   public void removeTerminalService(TerminalSocket terminalSocket) {
     Integer terminalSocketHashcode = terminalSocket.hashCode();
     if (terminalSocket2Service.containsKey(terminalSocketHashcode)) {
-      terminalSocket2Service.remove(terminalSocketHashcode);
+      terminalSocket2Service.remove(terminalSocketHashcode).close();
     } else {
       LOGGER.error("Can't find TerminalSocket: " + terminalSocketHashcode);
       LOGGER.error(terminalSocket2Service.toString());

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/service/TerminalService.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/service/TerminalService.java
@@ -35,8 +35,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
-public class TerminalService {
+public class TerminalService implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(TerminalService.class);
 
   private String[] termCommand;
@@ -145,6 +146,39 @@ public class TerminalService {
       if (Objects.nonNull(process)) {
         process.setWinSize(new WinSize(this.columns, this.rows));
       }
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (outputWriter != null) {
+        outputWriter.close();
+      }
+      if (inputReader != null) {
+        inputReader.close();
+      }
+      if (errorReader != null) {
+        errorReader.close();
+      }
+    } catch (IOException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+
+    if (process != null) {
+      destroyProcess(process);
+    }
+  }
+
+  private void destroyProcess(PtyProcess process) {
+    process.destroy();
+    try {
+      if (!process.waitFor(5L, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      process.destroyForcibly();
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

This PR ensures that the `PtyProcess` created for the interactive shell terminal in the Shell Interpreter is terminated when the terminal WebSocket is closed.
Previously, the process was not closed when the terminal was closed. This could allow shell processes to accumulate in the background.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6691

### How should this be tested?
Run a paragraph with `%sh.terminal` and confirm that a shell terminal process is started.
Move away from the notebook page or close the browser tab, then confirm that the same process exits.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
