### PR TITLE
[ZEPPELIN-6646] validate websocket payloads

### DIFF
--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message-payload-guards/index.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message-payload-guards/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MessageReceiveDataTypeMap } from '../interfaces/message-data-type-map.interface';
+import { OP } from '../interfaces/message-operator.interface';
+
+import { isListUpdateNoteJobsPayload } from './job';
+
+export type MessagePayloadGuard = (value: unknown) => boolean;
+
+type ReceiveOP = keyof MessageReceiveDataTypeMap;
+
+const MESSAGE_PAYLOAD_GUARDS: Partial<Record<ReceiveOP, MessagePayloadGuard>> = {
+  [OP.LIST_UPDATE_NOTE_JOBS]: isListUpdateNoteJobsPayload
+};
+
+export const getMessagePayloadGuard = (op: ReceiveOP): MessagePayloadGuard | undefined => {
+  return MESSAGE_PAYLOAD_GUARDS[op];
+};

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message-payload-guards/index.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message-payload-guards/index.ts
@@ -19,6 +19,11 @@ export type MessagePayloadGuard = (value: unknown) => boolean;
 
 type ReceiveOP = keyof MessageReceiveDataTypeMap;
 
+/**
+ * Runtime payload guards are registered only for OPs with a demonstrated
+ * payload-shape failure. Add new guards when a concrete runtime failure
+ * shows that validation is needed.
+ */
 const MESSAGE_PAYLOAD_GUARDS: Partial<Record<ReceiveOP, MessagePayloadGuard>> = {
   [OP.LIST_UPDATE_NOTE_JOBS]: isListUpdateNoteJobsPayload
 };

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message-payload-guards/job.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message-payload-guards/job.ts
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const isJobUpdate = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (typeof value.noteId !== 'string') {
+    return false;
+  }
+
+  if (typeof value.isRemoved !== 'boolean') {
+    return false;
+  }
+
+  if (value.isRemoved) {
+    return true;
+  }
+
+  return typeof value.noteName === 'string';
+};
+
+export const isListUpdateNoteJobsPayload = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const noteRunningJobs = value.noteRunningJobs;
+
+  if (!isRecord(noteRunningJobs)) {
+    return false;
+  }
+
+  return Array.isArray(noteRunningJobs.jobs) && noteRunningJobs.jobs.every(isJobUpdate);
+};

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.spec.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.spec.ts
@@ -10,7 +10,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { MessageReceiveDataTypeMap } from './interfaces/message-data-type-map.interface';
 import { OP } from './interfaces/message-operator.interface';
@@ -19,6 +19,10 @@ import { Message } from './message';
 
 const asReceivedMessage = (message: unknown): WebSocketMessage<MessageReceiveDataTypeMap> =>
   message as WebSocketMessage<MessageReceiveDataTypeMap>;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('Message.receive', () => {
   it('passes a non-removal job update with noteName', () => {
@@ -74,9 +78,10 @@ describe('Message.receive', () => {
     expect(listener).toHaveBeenCalledWith(data);
   });
 
-  it('filters a non-removal job update without noteName', () => {
+  it('filters a non-removal job update without noteName and warns with the OP only', () => {
     const message = new Message();
     const listener = vi.fn();
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     message.receive(OP.LIST_UPDATE_NOTE_JOBS).subscribe(listener);
 
@@ -97,11 +102,16 @@ describe('Message.receive', () => {
     );
 
     expect(listener).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      `Dropped WebSocket OP ${String(OP.LIST_UPDATE_NOTE_JOBS)}: payload failed validation`
+    );
   });
 
   it('filters a payload without a jobs array', () => {
     const message = new Message();
     const listener = vi.fn();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     message.receive(OP.LIST_UPDATE_NOTE_JOBS).subscribe(listener);
 

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.spec.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MessageReceiveDataTypeMap } from './interfaces/message-data-type-map.interface';
+import { OP } from './interfaces/message-operator.interface';
+import type { WebSocketMessage } from './interfaces/websocket-message.interface';
+import { Message } from './message';
+
+const asReceivedMessage = (message: unknown): WebSocketMessage<MessageReceiveDataTypeMap> =>
+  message as WebSocketMessage<MessageReceiveDataTypeMap>;
+
+describe('Message.receive', () => {
+  it('passes a non-removal job update with noteName', () => {
+    const message = new Message();
+    const listener = vi.fn();
+    const data = {
+      noteRunningJobs: {
+        jobs: [
+          {
+            noteId: 'note-1',
+            noteName: 'Test Note',
+            isRemoved: false
+          }
+        ]
+      }
+    };
+
+    message.receive(OP.LIST_UPDATE_NOTE_JOBS).subscribe(listener);
+
+    message.shortCircuit(
+      asReceivedMessage({
+        op: OP.LIST_UPDATE_NOTE_JOBS,
+        data
+      })
+    );
+
+    expect(listener).toHaveBeenCalledWith(data);
+  });
+
+  it('passes a partial removal payload without noteName', () => {
+    const message = new Message();
+    const listener = vi.fn();
+    const data = {
+      noteRunningJobs: {
+        jobs: [
+          {
+            noteId: 'note-1',
+            isRemoved: true
+          }
+        ]
+      }
+    };
+
+    message.receive(OP.LIST_UPDATE_NOTE_JOBS).subscribe(listener);
+
+    message.shortCircuit(
+      asReceivedMessage({
+        op: OP.LIST_UPDATE_NOTE_JOBS,
+        data
+      })
+    );
+
+    expect(listener).toHaveBeenCalledWith(data);
+  });
+
+  it('filters a non-removal job update without noteName', () => {
+    const message = new Message();
+    const listener = vi.fn();
+
+    message.receive(OP.LIST_UPDATE_NOTE_JOBS).subscribe(listener);
+
+    message.shortCircuit(
+      asReceivedMessage({
+        op: OP.LIST_UPDATE_NOTE_JOBS,
+        data: {
+          noteRunningJobs: {
+            jobs: [
+              {
+                noteId: 'note-1',
+                isRemoved: false
+              }
+            ]
+          }
+        }
+      })
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('filters a payload without a jobs array', () => {
+    const message = new Message();
+    const listener = vi.fn();
+
+    message.receive(OP.LIST_UPDATE_NOTE_JOBS).subscribe(listener);
+
+    message.shortCircuit(
+      asReceivedMessage({
+        op: OP.LIST_UPDATE_NOTE_JOBS,
+        data: {
+          noteRunningJobs: {}
+        }
+      })
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('keeps existing behavior for an OP without a guard', () => {
+    const message = new Message();
+    const listener = vi.fn();
+    const data = {};
+
+    message.receive(OP.NOTE).subscribe(listener);
+
+    message.shortCircuit(
+      asReceivedMessage({
+        op: OP.NOTE,
+        data
+      })
+    );
+
+    expect(listener).toHaveBeenCalledWith(data);
+  });
+});

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -30,6 +30,8 @@ import {
 } from './interfaces/message-paragraph.interface';
 import { WebSocketMessage } from './interfaces/websocket-message.interface';
 
+import { getMessagePayloadGuard } from './message-payload-guards';
+
 export type ArgumentsType<T> = T extends (...args: infer U) => void ? U : never;
 
 export type SendArgumentsType<K extends keyof MessageSendDataTypeMap> = MessageSendDataTypeMap[K] extends undefined
@@ -175,6 +177,15 @@ export class Message {
   receive<K extends keyof MessageReceiveDataTypeMap>(op: K): Observable<Record<K, MessageReceiveDataTypeMap[K]>[K]> {
     return this.received$.pipe(
       filter(message => message.op === op),
+      filter(message => {
+        const guard = getMessagePayloadGuard(op);
+
+        if (!guard) {
+          return true;
+        }
+
+        return guard(message.data);
+      }),
       map(message => message.data)
     ) as Observable<Record<K, MessageReceiveDataTypeMap[K]>[K]>;
   }

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -175,16 +175,18 @@ export class Message {
   }
 
   receive<K extends keyof MessageReceiveDataTypeMap>(op: K): Observable<Record<K, MessageReceiveDataTypeMap[K]>[K]> {
+    const guard = getMessagePayloadGuard(op);
+
     return this.received$.pipe(
       filter(message => message.op === op),
       filter(message => {
-        const guard = getMessagePayloadGuard(op);
-
-        if (!guard) {
+        if (!guard || guard(message.data)) {
           return true;
         }
 
-        return guard(message.data);
+        // The payload can be large and carries note names, so log the OP alone.
+        console.warn(`Dropped WebSocket OP ${String(op)}: payload failed validation`);
+        return false;
       }),
       map(message => message.data)
     ) as Observable<Record<K, MessageReceiveDataTypeMap[K]>[K]>;

--- a/zeppelin-web-angular/src/app/core/message-listener/message-listener.spec.ts
+++ b/zeppelin-web-angular/src/app/core/message-listener/message-listener.spec.ts
@@ -19,10 +19,14 @@ import { MessageListener, MessageListenersManager } from './message-listener';
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe('MessageListener', () => {
-  it('logs handler errors with the OP and keeps the subscription active', () => {
+  it('logs handler errors with the OP, rethrows them, and keeps the subscription active', () => {
+    // RxJS rethrows an error thrown inside `next` from a timer, so the subscription itself survives.
+    vi.useFakeTimers();
+
     const received$ = new Subject<MessageReceiveDataTypeMap[OP.NOTE]>();
     const messageService = {
       receive: vi.fn(() => received$.asObservable())
@@ -55,6 +59,7 @@ describe('MessageListener', () => {
 
     expect(component.calls).toBe(2);
     expect(consoleError).toHaveBeenCalledWith(`Failed to handle WebSocket OP ${String(OP.NOTE)}`, error);
+    expect(() => vi.runAllTimers()).toThrow(error);
   });
 
   it('passes received data to the handler', () => {

--- a/zeppelin-web-angular/src/app/core/message-listener/message-listener.spec.ts
+++ b/zeppelin-web-angular/src/app/core/message-listener/message-listener.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Subject } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Message, OP, MessageReceiveDataTypeMap } from '@zeppelin/sdk';
+
+import { MessageListener, MessageListenersManager } from './message-listener';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MessageListener', () => {
+  it('logs handler errors with the OP and keeps the subscription active', () => {
+    const received$ = new Subject<MessageReceiveDataTypeMap[OP.NOTE]>();
+    const messageService = {
+      receive: vi.fn(() => received$.asObservable())
+    } as unknown as Message;
+
+    const error = new Error('boom');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    class TestComponent extends MessageListenersManager {
+      calls = 0;
+
+      handleNote(_data: MessageReceiveDataTypeMap[OP.NOTE]): void {
+        this.calls++;
+
+        if (this.calls === 1) {
+          throw error;
+        }
+      }
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(TestComponent.prototype, 'handleNote')!;
+
+    MessageListener(OP.NOTE)(TestComponent.prototype, 'handleNote', descriptor);
+
+    const component = new TestComponent(messageService);
+    const data = {} as MessageReceiveDataTypeMap[OP.NOTE];
+
+    received$.next(data);
+    received$.next(data);
+
+    expect(component.calls).toBe(2);
+    expect(consoleError).toHaveBeenCalledWith(`Failed to handle WebSocket OP ${String(OP.NOTE)}`, error);
+  });
+
+  it('passes received data to the handler', () => {
+    const received$ = new Subject<MessageReceiveDataTypeMap[OP.NOTE]>();
+    const messageService = {
+      receive: vi.fn(() => received$.asObservable())
+    } as unknown as Message;
+
+    class TestComponent extends MessageListenersManager {
+      receivedData?: MessageReceiveDataTypeMap[OP.NOTE];
+
+      handleNote(data: MessageReceiveDataTypeMap[OP.NOTE]): void {
+        this.receivedData = data;
+      }
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(TestComponent.prototype, 'handleNote')!;
+
+    MessageListener(OP.NOTE)(TestComponent.prototype, 'handleNote', descriptor);
+
+    const component = new TestComponent(messageService);
+    const data = {} as MessageReceiveDataTypeMap[OP.NOTE];
+
+    received$.next(data);
+
+    expect(component.receivedData).toBe(data);
+  });
+});

--- a/zeppelin-web-angular/src/app/core/message-listener/message-listener.ts
+++ b/zeppelin-web-angular/src/app/core/message-listener/message-listener.ts
@@ -49,8 +49,12 @@ export function MessageListener<K extends keyof MessageReceiveDataTypeMap>(op: K
 
       this.__zeppelinMessageListeners$__.add(
         this.messageService.receive(op).subscribe(data => {
-          // @ts-ignore
-          oldValue.apply(this, [data]);
+          try {
+            // @ts-ignore
+            oldValue.apply(this, [data]);
+          } catch (error) {
+            console.error(`Failed to handle WebSocket OP ${String(op)}`, error);
+          }
         })
       );
     };

--- a/zeppelin-web-angular/src/app/core/message-listener/message-listener.ts
+++ b/zeppelin-web-angular/src/app/core/message-listener/message-listener.ts
@@ -54,6 +54,7 @@ export function MessageListener<K extends keyof MessageReceiveDataTypeMap>(op: K
             oldValue.apply(this, [data]);
           } catch (error) {
             console.error(`Failed to handle WebSocket OP ${String(op)}`, error);
+            throw error;
           }
         })
       );


### PR DESCRIPTION
### What is this PR for?
WebSocket payloads are currently trusted after checking only the operation name. `Message.receive()` maps `message.data` to its declared TypeScript type without runtime validation, so malformed payloads can reach component handlers unchanged.

This PR adds an OP-based runtime payload guard convention at the SDK receive boundary. Guards are registered only for operations with a demonstrated payload failure, rather than auditing or validating every WebSocket message up front.

`Message.receive()` was chosen as the validation boundary because it already has both the OP and payload before the data is passed to subscribers, while keeping the existing interceptor contract unchanged.

`LIST_UPDATE_NOTE_JOBS` is the first guarded operation because `ZEPPELIN-6551` demonstrated a concrete failure around partial job-removal payloads in the Job Manager. The guard preserves valid removal stubs and filters malformed non-removal updates before they reach subscribers. Additional OPs can be added to the registry when a concrete runtime failure demonstrates the need for validation.

It also catches errors thrown by `@MessageListener` handlers and logs them with the corresponding OP so the failure can be attributed to the WebSocket operation that triggered it.

`ZEPPELIN-6645` was considered as part of the validation boundary. An empty `interpreterSettings` array is a legitimate server response when the user is not authorized for any interpreter setting. Since the payload shape itself is valid, the non-empty assumption belongs to the note-create handler rather than the WebSocket validation layer, so this PR does not add a shared payload guard for that case.


### What type of PR is it?
Bug Fix

### Todos
* [x] - Add an OP-based runtime payload guard registry
* [x] - Add validation for `LIST_UPDATE_NOTE_JOBS`
* [x] - Apply registered payload guards in `Message.receive()`
* [x] - Catch `@MessageListener` handler errors and log the corresponding OP
* [x] - Add regression tests for payload validation and handler error handling

### What is the Jira issue?
[[ZEPPELIN-6646]](https://issues.apache.org/jira/browse/ZEPPELIN-6646)

### How should this be tested?
```bash
cd zeppelin-web-angular
npm run test:shell -- message.spec.ts
npm run test:shell -- message-listener.spec.ts
```
Both test suites pass successfully.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
