### PR TITLE
[ZEPPELIN-6313] Drop configuration WS endpoint in backend

### DIFF
--- a/zeppelin-common/src/main/java/org/apache/zeppelin/common/Message.java
+++ b/zeppelin-common/src/main/java/org/apache/zeppelin/common/Message.java
@@ -152,10 +152,6 @@ public class Message implements JsonSerializable {
 
     ANGULAR_OBJECT_CLIENT_UNBIND, // [c-s] angular object unbind from AngularJS z object
 
-    LIST_CONFIGURATIONS,          // [c-s] ask all key/value pairs of configurations
-    CONFIGURATIONS_INFO,          // [s-c] all key/value pairs of configurations
-                                  // @param settings serialized Map<String, String> object
-
     CHECKPOINT_NOTE,              // [c-s] checkpoint note to storage repository
                                   // @param noteId
                                   // @param checkpointName

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -88,7 +88,6 @@ import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl.Revision
 import org.apache.zeppelin.rest.exception.ForbiddenException;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
-import org.apache.zeppelin.service.ConfigurationService;
 import org.apache.zeppelin.service.JobManagerService;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
@@ -162,7 +161,6 @@ public class NotebookServer implements AngularObjectRegistryListener,
   private Provider<NoteParser> noteParser;
   private Provider<NotebookService> notebookServiceProvider;
   private AuthorizationService authorizationService;
-  private Provider<ConfigurationService> configurationServiceProvider;
   private Provider<JobManagerService> jobManagerServiceProvider;
 
   public NotebookServer() {
@@ -217,12 +215,6 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
 
   @Inject
-  public void setConfigurationService(
-      Provider<ConfigurationService> configurationServiceProvider) {
-    this.configurationServiceProvider = configurationServiceProvider;
-  }
-
-  @Inject
   public void setJobManagerService(
       Provider<JobManagerService> jobManagerServiceProvider) {
     this.jobManagerServiceProvider = jobManagerServiceProvider;
@@ -234,10 +226,6 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
   public NotebookService getNotebookService() {
     return notebookServiceProvider.get();
-  }
-
-  public ConfigurationService getConfigurationService() {
-    return configurationServiceProvider.get();
   }
 
   public synchronized JobManagerService getJobManagerService() {
@@ -510,9 +498,6 @@ public class NotebookServer implements AngularObjectRegistryListener,
           break;
         case ANGULAR_OBJECT_CLIENT_UNBIND:
           angularObjectClientUnbind(conn, receivedMessage);
-          break;
-        case LIST_CONFIGURATIONS:
-          sendAllConfigurations(conn, context, receivedMessage);
           break;
         case CHECKPOINT_NOTE:
           checkpointNote(conn, context, receivedMessage);
@@ -1666,20 +1651,6 @@ public class NotebookServer implements AngularObjectRegistryListener,
         return null;
       });
 
-  }
-
-  private void sendAllConfigurations(NotebookSocket conn,
-                                     ServiceContext context,
-                                     Message message) throws IOException {
-
-    getConfigurationService().getAllProperties(context,
-        new WebSocketServiceCallback<Map<String, String>>(conn) {
-          @Override
-          public void onSuccess(Map<String, String> properties, ServiceContext context) throws IOException {
-            super.onSuccess(properties, context);
-            conn.send(serializeMessage(new Message(OP.CONFIGURATIONS_INFO).put("configurations", properties)));
-          }
-        });
   }
 
   private void checkpointNote(NotebookSocket conn,

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
@@ -282,18 +282,6 @@ export enum OP {
 
   /**
    * [c-s]
-   * @deprecated Retained for backend wire contract compatibility. Use ConfigurationService REST APIs instead.
-   */
-  LIST_CONFIGURATIONS = 'LIST_CONFIGURATIONS',
-
-  /**
-   * [s-c]
-   * @deprecated Retained for backend wire contract compatibility. Use ConfigurationService REST APIs instead.
-   */
-  CONFIGURATIONS_INFO = 'CONFIGURATIONS_INFO',
-
-  /**
-   * [c-s]
    * checkpoint note to storage repository
    * @param noteId
    * @param checkpointName


### PR DESCRIPTION
### What is this PR for?
Currently, configuration data is fetched through REST APIs introduced by #5099. With the frontend no longer using the configuration WebSocket flow, this PR removes the remaining backend WebSocket path for configuration data.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
[[ZEPPELIN-6313]](https://issues.apache.org/jira/browse/ZEPPELIN/6313)

### How should this be tested?
- Open /#/configuration and verify it loads configurations via GET /api/configurations/all
- Import/export a note and verify it fetches GET /api/configurations/client

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
