### PR TITLE
[ZEPPELIN-6702] Fix shell terminal startup hang on macOS with JDK 17.0.13

### DIFF
--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -35,19 +35,10 @@
     <interpreter.name>sh</interpreter.name>
 
     <!--library versions -->
-    <pty4j.version>0.12.10-jdk8</pty4j.version>
+    <pty4j.version>0.13.12</pty4j.version>
     <jinjava.version>2.4.0</jinjava.version>
     <guava.version>32.0.0-jre</guava.version>
   </properties>
-
-  <!-- pty4j library not in maven central repository (http://repo.maven.apache.org/maven2) -->
-  <repositories>
-    <repository>
-      <id>jetbrains-intellij-dependencies</id>
-      <name>JetBrains Pty4j Repository</name>
-      <url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies</url>
-    </repository>
-  </repositories>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
### What is this PR for?

Upgrade pty4j from `0.12.10-jdk8` to `0.13.12` to avoid excessive shell terminal startup delays with high FD limits.

Reproduced on macOS with JDK 17.0.13, where the FD limit was `INT_MAX`. The old pty4j iterates through the entire range before starting the shell.

JDK 17.0.14 reduced the macOS FD limit, mitigating this issue. Upgrading pty4j avoids excessive startup delays when the FD limit remains high.

Also remove the JetBrains repository declaration, as the updated dependency is available from Maven Central.

 ### What type of PR is it?

  Bug Fix

### What is the Jira issue?

  https://issues.apache.org/jira/browse/ZEPPELIN-6702

### How should this be tested?

  Verified locally:
  On macOS with JDK 17.0.13:
  - Run terminal tests:
    `./mvnw test -pl shell -Dtest=TerminalInterpreterTest`
  - In the Zeppelin UI, run a `%sh.terminal` paragraph. Confirm that a shell prompt appears.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N